### PR TITLE
DRA-103-Build-A-SiteMap-Generator

### DIFF
--- a/backend/src/seeders/05-20260103-SitemapSeeder.ts
+++ b/backend/src/seeders/05-20260103-SitemapSeeder.ts
@@ -3,6 +3,7 @@ import { Seeder } from "@jorgebodega/typeorm-seeding";
 import { DRASitemapEntry } from "../models/DRASitemapEntry.js";
 import { DRAUsersPlatform } from "../models/DRAUsersPlatform.js";
 import { EPublishStatus } from "../types/EPublishStatus.js";
+import { EUserType } from "../types/EUserType.js";
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -17,7 +18,7 @@ export class SitemapSeeder extends Seeder {
         const userRepo = dataSource.getRepository(DRAUsersPlatform);
 
         // Find admin user (assuming first admin user or create logic)
-        let adminUser = await userRepo.findOne({ where: { user_type: 'admin' } });
+        let adminUser = await userRepo.findOne({ where: { user_type: EUserType.ADMIN } });
         
         if (!adminUser) {
             console.log('No admin user found. Skipping sitemap seeding.');


### PR DESCRIPTION
## Description

Fixed the issue was that the seeder was using the string literal 'admin' instead of the enum EUserType.ADMIN. I've:

Added the import for EUserType enum

Changed user_type: 'admin' to user_type: EUserType.ADMIN
Fixes: # (issue)

## Type of Change

Please delete options that are not relevant:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [ ] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce and validate the behavior.

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist

Please check all the boxes that apply:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [ ] I have linked the related issue(s) in the description.

## Screenshots (if applicable)

> Add screenshots to help explain your changes if visual updates are involved.

---