### PR TITLE
DRA-244-Remove-Function-Dropdown-In-Aggregate-Expressions

### DIFF
--- a/backend/src/constants/system-prompts.ts
+++ b/backend/src/constants/system-prompts.ts
@@ -165,12 +165,17 @@ When joining tables, ALWAYS include the foreign key columns:
    Step 6: Format as ["schema.table.column1", "schema.table.column2"]
    Step 7: VALIDATE: If aggregate_functions.length > 0, group_by_columns.length MUST be > 0
    Step 8: DOUBLE-CHECK: group_by_columns count should equal is_selected_column=true count
-7. Leave aggregate_expressions EMPTY unless dealing with complex mathematical expressions (rare)
+7. AGGREGATE EXPRESSIONS vs AGGREGATE FUNCTIONS:
+   - Use **aggregate_functions** for simple single-column aggregations: SUM(column), AVG(column), COUNT(DISTINCT column)
+   - Use **aggregate_expressions** for complex custom SQL expressions: SUM(col1 * col2), AVG(CASE WHEN...), COUNT(DISTINCT CASE...)
+   - aggregate_expressions format: {"expression": "complete SQL with function", "column_alias_name": "alias"}
+   - Example: {"expression": "SUM(quantity * price)", "column_alias_name": "total_revenue"}
+   - DO NOT separate function from expression - write complete SQL in expression field
 8. TABLE ALIASING FOR SELF-JOINS:
    - If same table appears multiple times, MUST use table_alias field with descriptive names
    - Each instance of the table must have a unique, role-based alias (e.g., "emp" and "mgr", NOT "users1" and "users2")
    - All columns from same aliased instance must use the same alias consistently
-8. SEMANTIC VALIDATION MANDATORY:
+9. SEMANTIC VALIDATION MANDATORY:
    - Verify JOIN conditions are logically possible
    - Ensure aggregations create meaningful segments
    - Check that grouping level matches analysis purpose
@@ -349,6 +354,17 @@ Respond with ONLY this JSON wrapped in code block with json tag:
   - \`column_alias_name\`: result column name
   - \`aggregate_function\`: 0='SUM', 1='AVG', 2='COUNT', 3='MIN', 4='MAX'
   - \`use_distinct\`: boolean
+
+- \`group_by.aggregate_expressions\`: Array of custom SQL aggregate expressions (for complex calculations)
+  - \`expression\`: Complete SQL expression INCLUDING aggregate function (e.g., "SUM(quantity * price)", "AVG(DISTINCT amount)")
+  - \`column_alias_name\`: result column name (REQUIRED)
+  - **IMPORTANT**: Write complete SQL in expression field - do NOT separate function from expression
+  - **Examples**:
+    - {"expression": "SUM(quantity * price)", "column_alias_name": "total_revenue"}
+    - {"expression": "AVG(CASE WHEN status='active' THEN amount ELSE 0 END)", "column_alias_name": "avg_active_amount"}
+    - {"expression": "COUNT(DISTINCT user_id)", "column_alias_name": "unique_users"}
+  - **When to use**: Complex formulas, CASE statements, mathematical operations between columns
+  - **When NOT to use**: Simple single-column aggregates (use aggregate_functions instead)
 
 - \`group_by.group_by_columns\`: Array of column references for GROUP BY clause (REQUIRED when using aggregates)
   - **Data Type**: Array of strings

--- a/backend/src/processors/DataSourceProcessor.ts
+++ b/backend/src/processors/DataSourceProcessor.ts
@@ -2589,13 +2589,11 @@ export class DataSourceProcessor {
             }
         });
         
-        // Add aggregate expressions to SELECT
+        // Add aggregate expressions to SELECT (use expression as-is, already contains complete SQL)
         query?.query_options?.group_by?.aggregate_expressions?.forEach((aggExpr: any) => {
-            if (aggExpr.aggregate_function !== '' && aggExpr.expression !== '') {
-                const distinctKeyword = aggExpr.use_distinct ? 'DISTINCT ' : '';
-                const aggregateFunc = aggregateFunctions[aggExpr.aggregate_function];
-                const aliasName = aggExpr?.column_alias_name !== '' ? aggExpr.column_alias_name : `agg_expr`;
-                selectColumns.push(`${aggregateFunc}(${distinctKeyword}${aggExpr.expression}) AS ${aliasName}`);
+            if (aggExpr.expression && aggExpr.expression.trim() !== '') {
+                const aliasName = aggExpr?.column_alias_name && aggExpr.column_alias_name !== '' ? aggExpr.column_alias_name : `agg_expr`;
+                selectColumns.push(`${aggExpr.expression} AS ${aliasName}`);
             }
         });
         
@@ -2830,10 +2828,8 @@ export class DataSourceProcessor {
                         const distinctKeyword = aggregateFunc.use_distinct ? 'DISTINCT ' : '';
                         havingColumn = `${funcName}(${distinctKeyword}${aggregateFunc.column})`;
                     } else if (aggregateExpr) {
-                        // Replace alias with full aggregate expression
-                        const funcName = aggregateFunctions[aggregateExpr.aggregate_function];
-                        const distinctKeyword = aggregateExpr.use_distinct ? 'DISTINCT ' : '';
-                        havingColumn = `${funcName}(${distinctKeyword}${aggregateExpr.expression})`;
+                        // Replace alias with full aggregate expression (use as-is)
+                        havingColumn = aggregateExpr.expression;
                     }
                     
                     // Handle value formatting - aggregates return numeric values


### PR DESCRIPTION
## Description
Simplify aggregate expressions to accept free-form SQL
BREAKING CHANGE: Aggregate expressions now accept complete SQL including functions
Changes:
- Removed function dropdown from aggregate expression UI (was limiting flexibility)
- Removed DISTINCT checkbox (users can write COUNT(DISTINCT col) directly)
- Updated backend to use expression field as-is without wrapping
- Modified frontend SQL generation to use expressions directly
- Fixed HAVING clause to use full expression without additional wrapping
- Updated AI system prompts with clear examples and usage guidelines

Before:
- Function: [SUM dropdown]
- Expression: quantity * price
- Generated: undefined(SUM([[quantity]] * [[price]]))

After:
- Expression: SUM(quantity * price) or AVG(CASE WHEN...)
- Generated: SUM(quantity * price) AS total_revenue

Benefits:
- Supports any SQL aggregate: SUM(a*b), STRING_AGG(), CASE expressions
- No artificial restrictions on aggregate functions
- Matches natural user/AI input patterns
- Clear separation from simple aggregate_functions feature

Files modified:
- backend/src/processors/DataSourceProcessor.ts (reconstructSQLFromJSON, HAVING)
- backend/src/constants/system-prompts.ts (added examples and guidance)
- frontend/components/data-model-builder.vue (UI, SQL generation, dropdowns)

## Type of Change

Please delete options that are not relevant:

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [x] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce and validate the behavior.

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist

Please check all the boxes that apply:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [ ] I have linked the related issue(s) in the description.

## Screenshots (if applicable)

> Add screenshots to help explain your changes if visual updates are involved.

---