### PR TITLE
Potential fix for code scanning alert no. 96: Use of externally-controlled format string

### DIFF
--- a/backend/src/routes/paddle-webhook.ts
+++ b/backend/src/routes/paddle-webhook.ts
@@ -496,7 +496,7 @@ router.post('/webhook', async (req: Request, res: Response) => {
         res.status(200).json({ success: true });
         
     } catch (error: any) {
-        console.error(`❌ Error processing webhook ${eventType}:`, error);
+        console.error('❌ Error processing webhook %s:', eventType, error);
         
         // Log error but still return 200 to prevent Paddle retries
         webhookEvent.error_message = error.message;


### PR DESCRIPTION
Potential fix for [https://github.com/Data-Research-Analysis/data-research-analysis-platform/security/code-scanning/96](https://github.com/Data-Research-Analysis/data-research-analysis-platform/security/code-scanning/96)

Use a constant format string for `console.error` and pass untrusted data as a separate argument.  
In `backend/src/routes/paddle-webhook.ts`, replace line 499’s template literal call:

- From: ``console.error(`❌ Error processing webhook ${eventType}:`, error);``
- To: `console.error('❌ Error processing webhook %s:', eventType, error);`

This preserves existing functionality and output intent while preventing user-controlled format-string injection. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
