### PR TITLE
Potential fix for code scanning alert no. 88: Resource exhaustion

### DIFF
--- a/backend/src/controllers/AIDataModelerController.ts
+++ b/backend/src/controllers/AIDataModelerController.ts
@@ -13,7 +13,6 @@ import { PostgresDataSource } from '../datasources/PostgresDataSource.js';
 import { MySQLDataSource } from '../datasources/MySQLDataSource.js';
 import { MariaDBDataSource } from '../datasources/MariaDBDataSource.js';
 import { DataModelProcessor } from '../processors/DataModelProcessor.js';  // Issue #361: Data model composition
-import { DataSourceSQLHelpers } from '../processors/helpers/DataSourceSQLHelpers.js';
 
 export class AIDataModelerController {
     /**
@@ -1034,7 +1033,12 @@ Keep it concise - aim for 200-300 words total.`;
                                 let columnRef = `${col.schema}.${col.table_name}.${col.column_name}`;
                                 // Include transform functions if present
                                 if (col.transform_function) {
-                                    const closeParens = ')'.repeat(DataSourceSQLHelpers.sanitizeCloseParensCount(col.transform_close_parens));
+                                    const rawCount = Number(col.transform_close_parens);
+                                    const closeParens = ')'.repeat(
+                                        (Number.isFinite(rawCount) && rawCount >= 1 && rawCount <= 20)
+                                            ? Math.floor(rawCount)
+                                            : 1
+                                    );
                                     columnRef = `${col.transform_function}(${columnRef}${closeParens}`;
                                 }
                                 return columnRef;

--- a/backend/src/controllers/AIDataModelerController.ts
+++ b/backend/src/controllers/AIDataModelerController.ts
@@ -13,6 +13,7 @@ import { PostgresDataSource } from '../datasources/PostgresDataSource.js';
 import { MySQLDataSource } from '../datasources/MySQLDataSource.js';
 import { MariaDBDataSource } from '../datasources/MariaDBDataSource.js';
 import { DataModelProcessor } from '../processors/DataModelProcessor.js';  // Issue #361: Data model composition
+import { DataSourceSQLHelpers } from '../processors/helpers/DataSourceSQLHelpers.js';
 
 export class AIDataModelerController {
     /**
@@ -1033,7 +1034,7 @@ Keep it concise - aim for 200-300 words total.`;
                                 let columnRef = `${col.schema}.${col.table_name}.${col.column_name}`;
                                 // Include transform functions if present
                                 if (col.transform_function) {
-                                    const closeParens = ')'.repeat(col.transform_close_parens || 1);
+                                    const closeParens = ')'.repeat(DataSourceSQLHelpers.sanitizeCloseParensCount(col.transform_close_parens));
                                     columnRef = `${col.transform_function}(${columnRef}${closeParens}`;
                                 }
                                 return columnRef;

--- a/backend/src/processors/helpers/DataSourceSQLHelpers.ts
+++ b/backend/src/processors/helpers/DataSourceSQLHelpers.ts
@@ -347,7 +347,12 @@ export class DataSourceSQLHelpers {
                             : `${column.schema}.${column.table_name}.${column.column_name}`;
 
                         if (column.transform_function) {
-                            const closeParens = ')'.repeat(DataSourceSQLHelpers.sanitizeCloseParensCount(column.transform_close_parens));
+                            const rawCount = Number(column.transform_close_parens);
+                            const closeParens = ')'.repeat(
+                                (Number.isFinite(rawCount) && rawCount >= 1 && rawCount <= 20)
+                                    ? Math.floor(rawCount)
+                                    : 1
+                            );
                             columnRef = `${column.transform_function}(${columnRef}${closeParens}`;
                         }
 

--- a/backend/src/processors/helpers/DataSourceSQLHelpers.ts
+++ b/backend/src/processors/helpers/DataSourceSQLHelpers.ts
@@ -333,7 +333,11 @@ export class DataSourceSQLHelpers {
                             : `${column.schema}.${column.table_name}.${column.column_name}`;
 
                         if (column.transform_function) {
-                            const closeParens = ')'.repeat(column.transform_close_parens || 1);
+                            const rawCloseParens = Number(column.transform_close_parens);
+                            const sanitizedCloseParensCount = Number.isFinite(rawCloseParens)
+                                ? Math.min(10, Math.max(1, Math.floor(rawCloseParens)))
+                                : 1;
+                            const closeParens = ')'.repeat(sanitizedCloseParensCount);
                             columnRef = `${column.transform_function}(${columnRef}${closeParens}`;
                         }
 

--- a/backend/src/processors/helpers/DataSourceSQLHelpers.ts
+++ b/backend/src/processors/helpers/DataSourceSQLHelpers.ts
@@ -7,20 +7,6 @@ export class DataSourceSQLHelpers {
     private constructor() { } // Non-instantiable
 
     /**
-     * Sanitize a user- or AI-provided closing-parenthesis count before passing it to
-     * `String.prototype.repeat()`.  Returns an integer clamped to [1, 20]:
-     *  - defaults to 1 when the value is missing or non-finite,
-     *  - floors to the nearest integer,
-     *  - allows up to 20 to accommodate complex nested SQL transforms while
-     *    preventing resource-exhaustion from unbounded `.repeat()` calls.
-     */
-    public static sanitizeCloseParensCount(value: unknown): number {
-        const n = Number(value);
-        if (!Number.isFinite(n)) return 1;
-        return Math.min(20, Math.max(1, Math.floor(n)));
-    }
-
-    /**
      * Escape SQL string values to prevent SQL injection
      */
     public static escapeSQL(value: any): string {

--- a/backend/src/processors/helpers/DataSourceSQLHelpers.ts
+++ b/backend/src/processors/helpers/DataSourceSQLHelpers.ts
@@ -7,6 +7,20 @@ export class DataSourceSQLHelpers {
     private constructor() { } // Non-instantiable
 
     /**
+     * Sanitize a user- or AI-provided closing-parenthesis count before passing it to
+     * `String.prototype.repeat()`.  Returns an integer clamped to [1, 20]:
+     *  - defaults to 1 when the value is missing or non-finite,
+     *  - floors to the nearest integer,
+     *  - allows up to 20 to accommodate complex nested SQL transforms while
+     *    preventing resource-exhaustion from unbounded `.repeat()` calls.
+     */
+    public static sanitizeCloseParensCount(value: unknown): number {
+        const n = Number(value);
+        if (!Number.isFinite(n)) return 1;
+        return Math.min(20, Math.max(1, Math.floor(n)));
+    }
+
+    /**
      * Escape SQL string values to prevent SQL injection
      */
     public static escapeSQL(value: any): string {
@@ -333,11 +347,7 @@ export class DataSourceSQLHelpers {
                             : `${column.schema}.${column.table_name}.${column.column_name}`;
 
                         if (column.transform_function) {
-                            const rawCloseParens = Number(column.transform_close_parens);
-                            const sanitizedCloseParensCount = Number.isFinite(rawCloseParens)
-                                ? Math.min(10, Math.max(1, Math.floor(rawCloseParens)))
-                                : 1;
-                            const closeParens = ')'.repeat(sanitizedCloseParensCount);
+                            const closeParens = ')'.repeat(DataSourceSQLHelpers.sanitizeCloseParensCount(column.transform_close_parens));
                             columnRef = `${column.transform_function}(${columnRef}${closeParens}`;
                         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Data-Research-Analysis/data-research-analysis-platform/security/code-scanning/88](https://github.com/Data-Research-Analysis/data-research-analysis-platform/security/code-scanning/88)

The fix is to strictly bound `transform_close_parens` before using it in `.repeat()`. In general, for resource-exhaustion issues, convert user input to a number, validate finiteness/integer-ness, and clamp to a safe min/max range.

Best fix (without changing intended behavior): in `backend/src/processors/helpers/DataSourceSQLHelpers.ts`, inside `reconstructSQLFromJSON` where `closeParens` is built, replace direct use of `column.transform_close_parens || 1` with sanitized logic:
- default to `1` when missing/invalid,
- floor to integer,
- clamp between `1` and a small safe max (for example `10`).

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
