### PR TITLE
377-meta-ads-attribution-enhancement-ad-creatives-custom-conversions

### DIFF
--- a/backend/src/__tests__/drivers/MetaAdsDriver.unit.test.ts
+++ b/backend/src/__tests__/drivers/MetaAdsDriver.unit.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { MetaAdsDriver } from '../../drivers/MetaAdsDriver.js';
+
+/**
+ * Unit tests for MetaAdsDriver
+ *
+ * DB-dependent methods (syncToDatabase, getSchema, etc.) are NOT exercised here
+ * since they require a live PostgreSQL connection.
+ * These tests cover:
+ *   - Singleton pattern
+ *   - getTableColumns dispatcher returns correct descriptor arrays
+ *   - getAdColumns includes url_tags and tracking_specs
+ *   - getCreativeColumns output (structure + key fields)
+ *   - getCustomConversionColumns output (structure + key fields)
+ *   - sumConversions helper behaviour
+ *   - Default date helpers return valid ISO strings
+ */
+describe('MetaAdsDriver', () => {
+    let driver: MetaAdsDriver;
+
+    beforeEach(() => {
+        driver = MetaAdsDriver.getInstance();
+    });
+
+    // -------------------------------------------------------------------------
+    // Singleton
+    // -------------------------------------------------------------------------
+    describe('Singleton Pattern', () => {
+        it('should return the same instance on repeated calls', () => {
+            const a = MetaAdsDriver.getInstance();
+            const b = MetaAdsDriver.getInstance();
+            expect(a).toBe(b);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // getTableColumns dispatcher
+    // -------------------------------------------------------------------------
+    describe('getTableColumns', () => {
+        const knownTypes = ['campaigns', 'adsets', 'ads', 'insights', 'creatives', 'custom_conversions'];
+
+        knownTypes.forEach(syncType => {
+            it(`should return a non-empty columns array for "${syncType}"`, () => {
+                const cols = (driver as any).getTableColumns(syncType);
+                expect(Array.isArray(cols)).toBe(true);
+                expect(cols.length).toBeGreaterThan(0);
+            });
+        });
+
+        it('should return an empty array for an unknown sync type', () => {
+            const cols = (driver as any).getTableColumns('unknown_sync_type');
+            expect(cols).toEqual([]);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Column descriptor shape helper
+    // -------------------------------------------------------------------------
+    function assertColumnShape(cols: any[]): void {
+        cols.forEach((col: any) => {
+            expect(typeof col.name).toBe('string');
+            expect(typeof col.type).toBe('string');
+            expect(col.name.length).toBeGreaterThan(0);
+            expect(col.type.length).toBeGreaterThan(0);
+            expect(typeof col.nullable).toBe('boolean');
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // getAdColumns
+    // -------------------------------------------------------------------------
+    describe('getAdColumns', () => {
+        it('should return a non-empty array', () => {
+            const cols = (driver as any).getAdColumns();
+            expect(Array.isArray(cols)).toBe(true);
+            expect(cols.length).toBeGreaterThan(0);
+        });
+
+        it('every column should have name, type, and nullable properties', () => {
+            assertColumnShape((driver as any).getAdColumns());
+        });
+
+        it('should include url_tags column of type TEXT', () => {
+            const cols: any[] = (driver as any).getAdColumns();
+            const col = cols.find((c: any) => c.name === 'url_tags');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('TEXT');
+            expect(col.nullable).toBe(true);
+        });
+
+        it('should include tracking_specs column of type JSONB', () => {
+            const cols: any[] = (driver as any).getAdColumns();
+            const col = cols.find((c: any) => c.name === 'tracking_specs');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('JSONB');
+            expect(col.nullable).toBe(true);
+        });
+
+        it('should include id column that is not nullable', () => {
+            const cols: any[] = (driver as any).getAdColumns();
+            const col = cols.find((c: any) => c.name === 'id');
+            expect(col).toBeDefined();
+            expect(col.nullable).toBe(false);
+        });
+
+        it('should include adset_id and campaign_id columns', () => {
+            const names = (driver as any).getAdColumns().map((c: any) => c.name);
+            expect(names).toContain('adset_id');
+            expect(names).toContain('campaign_id');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // getCreativeColumns
+    // -------------------------------------------------------------------------
+    describe('getCreativeColumns', () => {
+        it('should return a non-empty array', () => {
+            const cols = (driver as any).getCreativeColumns();
+            expect(Array.isArray(cols)).toBe(true);
+            expect(cols.length).toBeGreaterThan(0);
+        });
+
+        it('every column should have name, type, and nullable properties', () => {
+            assertColumnShape((driver as any).getCreativeColumns());
+        });
+
+        it('should include id column of type VARCHAR(50) that is not nullable', () => {
+            const cols: any[] = (driver as any).getCreativeColumns();
+            const col = cols.find((c: any) => c.name === 'id');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('VARCHAR(50)');
+            expect(col.nullable).toBe(false);
+        });
+
+        it('should include url_tags column of type TEXT', () => {
+            const cols: any[] = (driver as any).getCreativeColumns();
+            const col = cols.find((c: any) => c.name === 'url_tags');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('TEXT');
+            expect(col.nullable).toBe(true);
+        });
+
+        it('should include tracking_specs column of type JSONB', () => {
+            const cols: any[] = (driver as any).getCreativeColumns();
+            const col = cols.find((c: any) => c.name === 'tracking_specs');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('JSONB');
+            expect(col.nullable).toBe(true);
+        });
+
+        it('should include asset_feed_spec and object_story_spec JSONB columns', () => {
+            const cols: any[] = (driver as any).getCreativeColumns();
+            const names = cols.map((c: any) => c.name);
+            expect(names).toContain('asset_feed_spec');
+            expect(names).toContain('object_story_spec');
+            const assetCol = cols.find((c: any) => c.name === 'asset_feed_spec');
+            const storyCol = cols.find((c: any) => c.name === 'object_story_spec');
+            expect(assetCol.type).toBe('JSONB');
+            expect(storyCol.type).toBe('JSONB');
+        });
+
+        it('should include synced_at and updated_at timestamp columns', () => {
+            const names = (driver as any).getCreativeColumns().map((c: any) => c.name);
+            expect(names).toContain('synced_at');
+            expect(names).toContain('updated_at');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // getCustomConversionColumns
+    // -------------------------------------------------------------------------
+    describe('getCustomConversionColumns', () => {
+        it('should return a non-empty array', () => {
+            const cols = (driver as any).getCustomConversionColumns();
+            expect(Array.isArray(cols)).toBe(true);
+            expect(cols.length).toBeGreaterThan(0);
+        });
+
+        it('every column should have name, type, and nullable properties', () => {
+            assertColumnShape((driver as any).getCustomConversionColumns());
+        });
+
+        it('should include id column of type VARCHAR(50) that is not nullable', () => {
+            const cols: any[] = (driver as any).getCustomConversionColumns();
+            const col = cols.find((c: any) => c.name === 'id');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('VARCHAR(50)');
+            expect(col.nullable).toBe(false);
+        });
+
+        it('should include name column of type VARCHAR(255) that is not nullable', () => {
+            const cols: any[] = (driver as any).getCustomConversionColumns();
+            const col = cols.find((c: any) => c.name === 'name');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('VARCHAR(255)');
+            expect(col.nullable).toBe(false);
+        });
+
+        it('should include pixel_id and custom_event_type columns', () => {
+            const names = (driver as any).getCustomConversionColumns().map((c: any) => c.name);
+            expect(names).toContain('pixel_id');
+            expect(names).toContain('custom_event_type');
+        });
+
+        it('should include default_conversion_value of type DECIMAL(15,2)', () => {
+            const cols: any[] = (driver as any).getCustomConversionColumns();
+            const col = cols.find((c: any) => c.name === 'default_conversion_value');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('DECIMAL(15,2)');
+        });
+
+        it('should include is_archived BOOLEAN column', () => {
+            const cols: any[] = (driver as any).getCustomConversionColumns();
+            const col = cols.find((c: any) => c.name === 'is_archived');
+            expect(col).toBeDefined();
+            expect(col.type).toBe('BOOLEAN');
+        });
+
+        it('should include synced_at and updated_at timestamp columns', () => {
+            const names = (driver as any).getCustomConversionColumns().map((c: any) => c.name);
+            expect(names).toContain('synced_at');
+            expect(names).toContain('updated_at');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // sumConversions helper
+    // -------------------------------------------------------------------------
+    describe('sumConversions', () => {
+        it('should return 0 for undefined input', () => {
+            expect((driver as any).sumConversions(undefined)).toBe(0);
+        });
+
+        it('should return 0 for an empty array', () => {
+            expect((driver as any).sumConversions([])).toBe(0);
+        });
+
+        it('should sum offsite_conversion actions', () => {
+            const actions = [
+                { action_type: 'offsite_conversion.fb_pixel_purchase', value: '3' },
+                { action_type: 'offsite_conversion.fb_pixel_lead', value: '2' },
+            ];
+            expect((driver as any).sumConversions(actions)).toBe(5);
+        });
+
+        it('should sum lead and purchase actions', () => {
+            const actions = [
+                { action_type: 'lead', value: '4' },
+                { action_type: 'purchase', value: '1' },
+            ];
+            expect((driver as any).sumConversions(actions)).toBe(5);
+        });
+
+        it('should exclude non-conversion action types like link_click', () => {
+            const actions = [
+                { action_type: 'link_click', value: '100' },
+                { action_type: 'post_engagement', value: '200' },
+                { action_type: 'video_view', value: '50' },
+            ];
+            expect((driver as any).sumConversions(actions)).toBe(0);
+        });
+
+        it('should handle mixed conversion and non-conversion actions', () => {
+            const actions = [
+                { action_type: 'link_click', value: '100' },
+                { action_type: 'offsite_conversion.fb_pixel_purchase', value: '7' },
+                { action_type: 'post_engagement', value: '200' },
+            ];
+            expect((driver as any).sumConversions(actions)).toBe(7);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Default date helpers
+    // -------------------------------------------------------------------------
+    describe('Default date helpers', () => {
+        it('getDefaultEndDate should return today in YYYY-MM-DD format', () => {
+            const result: string = (driver as any).getDefaultEndDate();
+            expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+            const today = new Date().toISOString().split('T')[0];
+            expect(result).toBe(today);
+        });
+
+        it('getDefaultStartDate should return a date approximately 30 days before today', () => {
+            const result: string = (driver as any).getDefaultStartDate();
+            expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+            const expected = new Date();
+            expected.setDate(expected.getDate() - 30);
+            expect(result).toBe(expected.toISOString().split('T')[0]);
+        });
+
+        it('getDefaultStartDate should be before getDefaultEndDate', () => {
+            const start: string = (driver as any).getDefaultStartDate();
+            const end: string = (driver as any).getDefaultEndDate();
+            expect(new Date(start).getTime()).toBeLessThan(new Date(end).getTime());
+        });
+    });
+});

--- a/backend/src/drivers/MetaAdsDriver.ts
+++ b/backend/src/drivers/MetaAdsDriver.ts
@@ -821,6 +821,10 @@ export class MetaAdsDriver implements IAPIDriver {
                 synced_at TIMESTAMP DEFAULT NOW()
             )
         `);
+
+        // Migrate existing tables: add new columns if they don't already exist
+        await manager.query(`ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS url_tags TEXT`);
+        await manager.query(`ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS tracking_specs JSONB`);
         
         // Create indexes
         await manager.query(`CREATE INDEX IF NOT EXISTS idx_${tableName}_adset ON ${fullTableName}(adset_id)`);
@@ -886,6 +890,10 @@ export class MetaAdsDriver implements IAPIDriver {
                 updated_at TIMESTAMP DEFAULT NOW()
             )
         `);
+
+        // Migrate existing tables: add new columns if they don't already exist
+        await manager.query(`ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS url_tags TEXT`);
+        await manager.query(`ALTER TABLE ${fullTableName} ADD COLUMN IF NOT EXISTS tracking_specs JSONB`);
 
         await manager.query(`CREATE INDEX IF NOT EXISTS idx_${tableName}_status ON ${fullTableName}(status)`);
         await manager.query(`CREATE INDEX IF NOT EXISTS idx_${tableName}_synced_at ON ${fullTableName}(synced_at)`);

--- a/backend/src/drivers/MetaAdsDriver.ts
+++ b/backend/src/drivers/MetaAdsDriver.ts
@@ -13,6 +13,8 @@ import {
     IMetaCampaign,
     IMetaAdSet,
     IMetaAd,
+    IMetaAdCreative,
+    IMetaCustomConversion,
     IMetaInsights,
     IInsightsParams,
 } from '../types/IMetaAds.js';
@@ -113,7 +115,7 @@ export class MetaAdsDriver implements IAPIDriver {
             await manager.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`);
             
             // Get sync configuration
-            const syncTypes = connectionDetails.api_config?.report_types || ['campaigns', 'adsets', 'ads', 'insights'];
+            const syncTypes = connectionDetails.api_config?.report_types || ['campaigns', 'adsets', 'ads', 'insights', 'creatives', 'custom_conversions'];
             const startDate = connectionDetails.api_config?.start_date || this.getDefaultStartDate();
             const endDate = connectionDetails.api_config?.end_date || this.getDefaultEndDate();
             
@@ -189,6 +191,10 @@ export class MetaAdsDriver implements IAPIDriver {
                 return await this.syncAds(manager, schemaName, dataSourceId, usersPlatformId, connectionDetails);
             case 'insights':
                 return await this.syncInsights(manager, schemaName, dataSourceId, usersPlatformId, connectionDetails, dateRange);
+            case 'creatives':
+                return await this.syncCreatives(manager, schemaName, dataSourceId, usersPlatformId, connectionDetails);
+            case 'custom_conversions':
+                return await this.syncCustomConversions(manager, schemaName, dataSourceId, usersPlatformId, connectionDetails);
             default:
                 console.warn(`⚠️ Unknown sync type: ${entityType}`);
                 return 0;
@@ -440,6 +446,108 @@ export class MetaAdsDriver implements IAPIDriver {
         
         return totalInserted;
     }
+
+    /**
+     * Sync ad creatives
+     */
+    private async syncCreatives(
+        manager: any,
+        schemaName: string,
+        dataSourceId: number,
+        usersPlatformId: number,
+        connectionDetails: IAPIConnectionDetails
+    ): Promise<number> {
+        const tableMetadataService = TableMetadataService.getInstance();
+        const logicalTableName = 'creatives';
+        const tableName = tableMetadataService.generatePhysicalTableName(dataSourceId, logicalTableName);
+        const adAccountId = connectionDetails.api_config?.ad_account_id!;
+
+        await this.createCreativesTable(manager, schemaName, tableName);
+
+        await tableMetadataService.storeTableMetadata(manager, {
+            dataSourceId,
+            usersPlatformId,
+            schemaName,
+            physicalTableName: tableName,
+            logicalTableName,
+            originalSheetName: logicalTableName,
+            tableType: 'meta_ads'
+        });
+
+        const creatives = await this.metaAdsService.getCreatives(
+            adAccountId,
+            connectionDetails.oauth_access_token
+        );
+
+        if (creatives.length === 0) {
+            console.log('   No creatives found');
+            return 0;
+        }
+
+        const batchSize = 500;
+        let totalInserted = 0;
+
+        for (let i = 0; i < creatives.length; i += batchSize) {
+            const batch = creatives.slice(i, i + batchSize);
+            const records = batch.map(creative => this.transformCreative(creative));
+
+            await this.batchUpsert(manager, schemaName, tableName, records, ['id']);
+            totalInserted += batch.length;
+        }
+
+        return totalInserted;
+    }
+
+    /**
+     * Sync custom conversions
+     */
+    private async syncCustomConversions(
+        manager: any,
+        schemaName: string,
+        dataSourceId: number,
+        usersPlatformId: number,
+        connectionDetails: IAPIConnectionDetails
+    ): Promise<number> {
+        const tableMetadataService = TableMetadataService.getInstance();
+        const logicalTableName = 'custom_conversions';
+        const tableName = tableMetadataService.generatePhysicalTableName(dataSourceId, logicalTableName);
+        const adAccountId = connectionDetails.api_config?.ad_account_id!;
+
+        await this.createCustomConversionsTable(manager, schemaName, tableName);
+
+        await tableMetadataService.storeTableMetadata(manager, {
+            dataSourceId,
+            usersPlatformId,
+            schemaName,
+            physicalTableName: tableName,
+            logicalTableName,
+            originalSheetName: logicalTableName,
+            tableType: 'meta_ads'
+        });
+
+        const conversions = await this.metaAdsService.getCustomConversions(
+            adAccountId,
+            connectionDetails.oauth_access_token
+        );
+
+        if (conversions.length === 0) {
+            console.log('   No custom conversions found');
+            return 0;
+        }
+
+        const batchSize = 500;
+        let totalInserted = 0;
+
+        for (let i = 0; i < conversions.length; i += batchSize) {
+            const batch = conversions.slice(i, i + batchSize);
+            const records = batch.map(conversion => this.transformCustomConversion(conversion));
+
+            await this.batchUpsert(manager, schemaName, tableName, records, ['id']);
+            totalInserted += batch.length;
+        }
+
+        return totalInserted;
+    }
     
     /**
      * Transform campaign data for database insertion
@@ -494,9 +602,56 @@ export class MetaAdsDriver implements IAPIDriver {
             campaign_id: ad.campaign_id,
             status: ad.status,
             creative_id: ad.creative?.id || null,
+            url_tags: ad.url_tags || null,
+            tracking_specs: ad.tracking_specs ? JSON.stringify(ad.tracking_specs) : null,
             created_time: ad.created_time,
             updated_time: ad.updated_time,
             synced_at: new Date(),
+        };
+    }
+
+    /**
+     * Transform creative data for database insertion
+     */
+    private transformCreative(creative: IMetaAdCreative): any {
+        return {
+            id: creative.id,
+            name: creative.name || null,
+            title: creative.title || null,
+            body: creative.body || null,
+            call_to_action_type: creative.call_to_action_type || null,
+            link_url: creative.link_url || null,
+            image_url: creative.image_url || null,
+            video_id: creative.video_id || null,
+            asset_feed_spec: creative.asset_feed_spec ? JSON.stringify(creative.asset_feed_spec) : null,
+            object_story_spec: creative.object_story_spec ? JSON.stringify(creative.object_story_spec) : null,
+            status: creative.status || null,
+            effective_object_story_id: creative.effective_object_story_id || null,
+            url_tags: creative.url_tags || null,
+            tracking_specs: creative.tracking_specs ? JSON.stringify(creative.tracking_specs) : null,
+            synced_at: new Date(),
+            updated_at: new Date(),
+        };
+    }
+
+    /**
+     * Transform custom conversion data for database insertion
+     */
+    private transformCustomConversion(conversion: IMetaCustomConversion): any {
+        return {
+            id: conversion.id,
+            name: conversion.name,
+            rule: conversion.rule || null,
+            event_source_type: conversion.event_source_type || null,
+            pixel_id: conversion.pixel_id || null,
+            custom_event_type: conversion.custom_event_type || null,
+            default_conversion_value: conversion.default_conversion_value || null,
+            description: conversion.description || null,
+            creation_time: conversion.creation_time || null,
+            last_fired_time: conversion.last_fired_time || null,
+            is_archived: conversion.is_archived || false,
+            synced_at: new Date(),
+            updated_at: new Date(),
         };
     }
     
@@ -659,6 +814,8 @@ export class MetaAdsDriver implements IAPIDriver {
                 campaign_id VARCHAR(50),
                 status VARCHAR(20),
                 creative_id VARCHAR(50),
+                url_tags TEXT,
+                tracking_specs JSONB,
                 created_time TIMESTAMP,
                 updated_time TIMESTAMP,
                 synced_at TIMESTAMP DEFAULT NOW()
@@ -705,6 +862,64 @@ export class MetaAdsDriver implements IAPIDriver {
     }
 
     /**
+     * Create creatives table
+     */
+    private async createCreativesTable(manager: any, schemaName: string, tableName: string): Promise<void> {
+        const fullTableName = `${schemaName}.${tableName}`;
+        await manager.query(`
+            CREATE TABLE IF NOT EXISTS ${fullTableName} (
+                id VARCHAR(50) PRIMARY KEY,
+                name VARCHAR(255),
+                title TEXT,
+                body TEXT,
+                call_to_action_type VARCHAR(100),
+                link_url TEXT,
+                image_url TEXT,
+                video_id VARCHAR(100),
+                asset_feed_spec JSONB,
+                object_story_spec JSONB,
+                status VARCHAR(50),
+                effective_object_story_id VARCHAR(100),
+                url_tags TEXT,
+                tracking_specs JSONB,
+                synced_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        `);
+
+        await manager.query(`CREATE INDEX IF NOT EXISTS idx_${tableName}_status ON ${fullTableName}(status)`);
+        await manager.query(`CREATE INDEX IF NOT EXISTS idx_${tableName}_synced_at ON ${fullTableName}(synced_at)`);
+    }
+
+    /**
+     * Create custom conversions table
+     */
+    private async createCustomConversionsTable(manager: any, schemaName: string, tableName: string): Promise<void> {
+        const fullTableName = `${schemaName}.${tableName}`;
+        await manager.query(`
+            CREATE TABLE IF NOT EXISTS ${fullTableName} (
+                id VARCHAR(50) PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                rule TEXT,
+                event_source_type VARCHAR(50),
+                pixel_id VARCHAR(100),
+                custom_event_type VARCHAR(100),
+                default_conversion_value DECIMAL(15,2),
+                description TEXT,
+                creation_time TIMESTAMP,
+                last_fired_time TIMESTAMP,
+                is_archived BOOLEAN DEFAULT FALSE,
+                synced_at TIMESTAMP DEFAULT NOW(),
+                updated_at TIMESTAMP DEFAULT NOW()
+            )
+        `);
+
+        await manager.query(`CREATE INDEX IF NOT EXISTS idx_${tableName}_event_type ON ${fullTableName}(custom_event_type)`);
+        await manager.query(`CREATE INDEX IF NOT EXISTS idx_${tableName}_pixel_id ON ${fullTableName}(pixel_id)`);
+        await manager.query(`CREATE INDEX IF NOT EXISTS idx_${tableName}_archived ON ${fullTableName}(is_archived)`);
+    }
+
+    /**
      * Get default start date (30 days ago)
      */
     private getDefaultStartDate(): string {
@@ -724,7 +939,7 @@ export class MetaAdsDriver implements IAPIDriver {
      * Get schema metadata for Meta Ads data source
      */
     public async getSchema(dataSourceId: number, connectionDetails: IAPIConnectionDetails): Promise<any> {
-        const syncTypes = connectionDetails.api_config?.report_types || ['campaigns', 'adsets', 'ads', 'insights'];
+        const syncTypes = connectionDetails.api_config?.report_types || ['campaigns', 'adsets', 'ads', 'insights', 'creatives', 'custom_conversions'];
         const schemaName = 'dra_meta_ads';
         const tableMetadataService = TableMetadataService.getInstance();
         
@@ -757,6 +972,10 @@ export class MetaAdsDriver implements IAPIDriver {
                 return this.getAdColumns();
             case 'insights':
                 return this.getInsightColumns();
+            case 'creatives':
+                return this.getCreativeColumns();
+            case 'custom_conversions':
+                return this.getCustomConversionColumns();
             default:
                 return [];
         }
@@ -806,6 +1025,8 @@ export class MetaAdsDriver implements IAPIDriver {
             { name: 'campaign_id', type: 'VARCHAR(50)', nullable: true },
             { name: 'status', type: 'VARCHAR(20)', nullable: true },
             { name: 'creative_id', type: 'VARCHAR(50)', nullable: true },
+            { name: 'url_tags', type: 'TEXT', nullable: true },
+            { name: 'tracking_specs', type: 'JSONB', nullable: true },
             { name: 'created_time', type: 'TIMESTAMP', nullable: true },
             { name: 'updated_time', type: 'TIMESTAMP', nullable: true },
             { name: 'synced_at', type: 'TIMESTAMP', nullable: true },
@@ -830,6 +1051,45 @@ export class MetaAdsDriver implements IAPIDriver {
             { name: 'cpm', type: 'DECIMAL(10,4)', nullable: true },
             { name: 'conversions', type: 'BIGINT', nullable: true },
             { name: 'synced_at', type: 'TIMESTAMP', nullable: true },
+        ];
+    }
+
+    private getCreativeColumns(): any[] {
+        return [
+            { name: 'id', type: 'VARCHAR(50)', nullable: false },
+            { name: 'name', type: 'VARCHAR(255)', nullable: true },
+            { name: 'title', type: 'TEXT', nullable: true },
+            { name: 'body', type: 'TEXT', nullable: true },
+            { name: 'call_to_action_type', type: 'VARCHAR(100)', nullable: true },
+            { name: 'link_url', type: 'TEXT', nullable: true },
+            { name: 'image_url', type: 'TEXT', nullable: true },
+            { name: 'video_id', type: 'VARCHAR(100)', nullable: true },
+            { name: 'asset_feed_spec', type: 'JSONB', nullable: true },
+            { name: 'object_story_spec', type: 'JSONB', nullable: true },
+            { name: 'status', type: 'VARCHAR(50)', nullable: true },
+            { name: 'effective_object_story_id', type: 'VARCHAR(100)', nullable: true },
+            { name: 'url_tags', type: 'TEXT', nullable: true },
+            { name: 'tracking_specs', type: 'JSONB', nullable: true },
+            { name: 'synced_at', type: 'TIMESTAMP', nullable: true },
+            { name: 'updated_at', type: 'TIMESTAMP', nullable: true },
+        ];
+    }
+
+    private getCustomConversionColumns(): any[] {
+        return [
+            { name: 'id', type: 'VARCHAR(50)', nullable: false },
+            { name: 'name', type: 'VARCHAR(255)', nullable: false },
+            { name: 'rule', type: 'TEXT', nullable: true },
+            { name: 'event_source_type', type: 'VARCHAR(50)', nullable: true },
+            { name: 'pixel_id', type: 'VARCHAR(100)', nullable: true },
+            { name: 'custom_event_type', type: 'VARCHAR(100)', nullable: true },
+            { name: 'default_conversion_value', type: 'DECIMAL(15,2)', nullable: true },
+            { name: 'description', type: 'TEXT', nullable: true },
+            { name: 'creation_time', type: 'TIMESTAMP', nullable: true },
+            { name: 'last_fired_time', type: 'TIMESTAMP', nullable: true },
+            { name: 'is_archived', type: 'BOOLEAN', nullable: true },
+            { name: 'synced_at', type: 'TIMESTAMP', nullable: true },
+            { name: 'updated_at', type: 'TIMESTAMP', nullable: true },
         ];
     }
     

--- a/backend/src/processors/MetaAdsProcessor.ts
+++ b/backend/src/processors/MetaAdsProcessor.ts
@@ -148,7 +148,7 @@ export class MetaAdsProcessor {
             token_expiry: expiryDate,
             api_config: {
                 ad_account_id: adAccountId,
-                report_types: syncTypes || ['campaigns', 'adsets', 'ads', 'insights'],
+                report_types: syncTypes || ['campaigns', 'adsets', 'ads', 'insights', 'creatives', 'custom_conversions'],
                 start_date: startDate,
                 end_date: endDate,
             },

--- a/backend/src/routes/meta_ads.ts
+++ b/backend/src/routes/meta_ads.ts
@@ -119,7 +119,7 @@ router.post('/add', validateJWT, requiresProductionAccess, async (req, res) => {
             syncConfig.name,
             syncConfig.accessToken,
             syncConfig.adAccountId,
-            syncConfig.syncTypes || ['campaigns', 'adsets', 'ads', 'insights'],
+            syncConfig.syncTypes || ['campaigns', 'adsets', 'ads', 'insights', 'creatives', 'custom_conversions'],
             syncConfig.startDate || defaultStart,
             syncConfig.endDate || new Date().toISOString().split('T')[0],
             req.body.tokenDetails,

--- a/backend/src/services/MetaAdsService.ts
+++ b/backend/src/services/MetaAdsService.ts
@@ -3,6 +3,8 @@ import {
     IMetaCampaign,
     IMetaAdSet,
     IMetaAd,
+    IMetaAdCreative,
+    IMetaCustomConversion,
     IMetaInsights,
     IInsightsParams,
     IMetaAPIResponse,
@@ -263,6 +265,8 @@ export class MetaAdsService {
             'campaign_id',
             'status',
             'creative',
+            'url_tags',
+            'tracking_specs',
             'created_time',
             'updated_time',
         ].join(',');
@@ -408,5 +412,108 @@ export class MetaAdsService {
             ...params,
             level: 'ad',
         });
+    }
+
+    /**
+     * Get ad creatives for an ad account
+     */
+    public async getCreatives(
+        adAccountId: string,
+        accessToken: string,
+        params?: { limit?: number }
+    ): Promise<IMetaAdCreative[]> {
+        const fields = [
+            'id',
+            'name',
+            'title',
+            'body',
+            'call_to_action_type',
+            'link_url',
+            'image_url',
+            'video_id',
+            'asset_feed_spec',
+            'object_story_spec',
+            'status',
+            'effective_object_story_id',
+            'url_tags',
+            'tracking_specs',
+        ].join(',');
+
+        let url = `${MetaAdsService.BASE_URL}/${MetaAdsService.API_VERSION}/${adAccountId}/adcreatives?fields=${fields}`;
+        if (params?.limit) {
+            url += `&limit=${params.limit}`;
+        }
+
+        console.log(`[Meta Ads] Fetching ad creatives for ${adAccountId}`);
+
+        try {
+            const creatives: IMetaAdCreative[] = [];
+            let nextUrl: string | undefined = url;
+
+            while (nextUrl) {
+                const response = await this.makeAPIRequest<IMetaAPIResponse<IMetaAdCreative>>(nextUrl, accessToken);
+                creatives.push(...response.data);
+
+                nextUrl = response.paging?.next;
+
+                if (nextUrl) {
+                    console.log(`   - Fetching next page (${creatives.length} creatives so far)...`);
+                }
+            }
+
+            console.log(`✅ [Meta Ads] Fetched ${creatives.length} ad creatives`);
+            return creatives;
+        } catch (error: any) {
+            console.error('❌ [Meta Ads] Failed to fetch ad creatives:', error);
+            throw new Error(`Failed to fetch ad creatives: ${error.message}`);
+        }
+    }
+
+    /**
+     * Get custom conversions for an ad account
+     */
+    public async getCustomConversions(
+        adAccountId: string,
+        accessToken: string
+    ): Promise<IMetaCustomConversion[]> {
+        const fields = [
+            'id',
+            'name',
+            'rule',
+            'event_source_type',
+            'pixel_id',
+            'custom_event_type',
+            'default_conversion_value',
+            'description',
+            'creation_time',
+            'last_fired_time',
+            'is_archived',
+        ].join(',');
+
+        const url = `${MetaAdsService.BASE_URL}/${MetaAdsService.API_VERSION}/${adAccountId}/customconversions?fields=${fields}`;
+
+        console.log(`[Meta Ads] Fetching custom conversions for ${adAccountId}`);
+
+        try {
+            const conversions: IMetaCustomConversion[] = [];
+            let nextUrl: string | undefined = url;
+
+            while (nextUrl) {
+                const response = await this.makeAPIRequest<IMetaAPIResponse<IMetaCustomConversion>>(nextUrl, accessToken);
+                conversions.push(...response.data);
+
+                nextUrl = response.paging?.next;
+
+                if (nextUrl) {
+                    console.log(`   - Fetching next page (${conversions.length} conversions so far)...`);
+                }
+            }
+
+            console.log(`✅ [Meta Ads] Fetched ${conversions.length} custom conversions`);
+            return conversions;
+        } catch (error: any) {
+            console.error('❌ [Meta Ads] Failed to fetch custom conversions:', error);
+            throw new Error(`Failed to fetch custom conversions: ${error.message}`);
+        }
     }
 }

--- a/backend/src/services/MetaOAuthService.ts
+++ b/backend/src/services/MetaOAuthService.ts
@@ -61,6 +61,7 @@ export class MetaOAuthService {
         return [
             'ads_read',              // Read ad account data
             'business_management',   // Access Business Manager accounts
+            'ads_management',        // Read creatives/custom conversions (App Review required)
         ];
     }
     

--- a/backend/src/types/IMetaAds.ts
+++ b/backend/src/types/IMetaAds.ts
@@ -8,7 +8,9 @@ export enum MetaAdsReportType {
     CAMPAIGNS = 'CAMPAIGNS',
     ADSETS = 'ADSETS',
     ADS = 'ADS',
-    INSIGHTS = 'INSIGHTS'
+    INSIGHTS = 'INSIGHTS',
+    CREATIVES = 'CREATIVES',
+    CUSTOM_CONVERSIONS = 'CUSTOM_CONVERSIONS'
 }
 
 // Meta Ad Account
@@ -60,8 +62,43 @@ export interface IMetaAd {
     campaign_id: string;
     status: string;
     creative?: { id: string };
+    url_tags?: string;        // UTM tracking string e.g. "utm_source=facebook&utm_campaign=..."
+    tracking_specs?: object; // click-to-website tracking configuration
     created_time: string;
     updated_time: string;
+}
+
+// Meta Ad Creative
+export interface IMetaAdCreative {
+    id: string;
+    name?: string;
+    title?: string;
+    body?: string;
+    call_to_action_type?: string;
+    link_url?: string;
+    image_url?: string;
+    video_id?: string;
+    asset_feed_spec?: any;
+    object_story_spec?: any;
+    status?: string;
+    effective_object_story_id?: string;
+    url_tags?: string;        // UTM tracking string on the creative destination URL
+    tracking_specs?: object; // click tracking configuration
+}
+
+// Meta Custom Conversion
+export interface IMetaCustomConversion {
+    id: string;
+    name: string;
+    rule: string;
+    event_source_type?: string;
+    pixel_id?: string;
+    custom_event_type?: string;
+    default_conversion_value?: number;
+    description?: string;
+    creation_time?: string;
+    last_fired_time?: string;
+    is_archived?: boolean;
 }
 
 // Meta Insights
@@ -107,7 +144,7 @@ export interface IMetaSyncConfig {
     name: string;
     adAccountId: string;
     accessToken: string;
-    syncTypes: string[];  // ['campaigns', 'adsets', 'ads', 'insights']
+    syncTypes: string[];  // ['campaigns', 'adsets', 'ads', 'insights', 'creatives', 'custom_conversions']
     startDate: string;
     endDate: string;
 }

--- a/frontend/composables/useMetaAds.ts
+++ b/frontend/composables/useMetaAds.ts
@@ -28,7 +28,7 @@ export const useMetaAds = () => {
      * Get available report types for Meta Ads
      */
     const getReportTypes = () => {
-        return [
+        const types = [
             {
                 id: 'campaigns',
                 name: 'Campaigns',
@@ -50,6 +50,20 @@ export const useMetaAds = () => {
                 description: 'Performance metrics (impressions, clicks, spend, conversions)'
             }
         ];
+
+        types.push({
+            id: 'creatives',
+            name: 'Ad Creatives',
+            description: 'Creative assets (headlines, body text, CTA, image/video references)'
+        });
+
+        types.push({
+            id: 'custom_conversions',
+            name: 'Custom Conversions',
+            description: 'Conversion definitions (event type, pixel reference, default conversion value)'
+        });
+
+        return types;
     };
 
     /**

--- a/frontend/pages/projects/[projectid]/data-sources/connect/meta-ads.vue
+++ b/frontend/pages/projects/[projectid]/data-sources/connect/meta-ads.vue
@@ -43,7 +43,14 @@ const state = reactive<State>({
 
     // Configuration
     dataSourceName: '',
-    selectedReportTypes: ['campaigns', 'adsets', 'ads', 'insights'] as string[],
+    selectedReportTypes: [
+        'campaigns',
+        'adsets',
+        'ads',
+        'insights',
+        'creatives',
+        'custom_conversions',
+    ] as string[],
     dateRange: 'last_30_days' as string,
     customStartDate: '',
     customEndDate: '',
@@ -58,7 +65,9 @@ const reportTypeOptions = [
     { id: 'campaigns', name: 'Campaigns', description: 'Campaign-level data (name, status, budget, objective)' },
     { id: 'adsets', name: 'Ad Sets', description: 'Ad set-level data (targeting, schedule, bid strategy)' },
     { id: 'ads', name: 'Ads', description: 'Individual ads (creative, status, preview URL)' },
-    { id: 'insights', name: 'Insights', description: 'Performance metrics (impressions, clicks, spend, conversions)' }
+    { id: 'insights', name: 'Insights', description: 'Performance metrics (impressions, clicks, spend, conversions)' },
+    { id: 'creatives', name: 'Ad Creatives', description: 'Creative assets (headlines, body text, CTA, image/video references)' },
+    { id: 'custom_conversions', name: 'Custom Conversions', description: 'Conversion definitions (event type, pixel reference, default conversion value)' },
 ];
 
 // Check for OAuth callback on mount
@@ -178,7 +187,7 @@ async function loadAdAccounts() {
                 title: 'No Accounts Found',
                 text: state.error,
                 icon: 'warning',
-                html: '<p>Please ensure you:</p><ul class="text-left ml-4 mt-2"><li>• Have a Business Manager account</li><li>• Have at least one ad account</li><li>• Have granted ads_read and business_management permissions</li></ul>'
+                html: '<p>Please ensure you:</p><ul class="text-left ml-4 mt-2"><li>• Have a Business Manager account</li><li>• Have at least one ad account</li><li>• Have granted ads_read, business_management, and ads_management permissions</li></ul>'
             });
         }
     } catch (error: any) {
@@ -375,7 +384,9 @@ definePageMeta({
                     <ul class="text-sm text-blue-800 space-y-1">
                         <li>• <strong>ads_read:</strong> Read access to your ads, campaigns, and performance data</li>
                         <li>• <strong>business_management:</strong> Access to ad accounts in Business Manager</li>
+                        <li>• <strong>ads_management:</strong> Read access for creatives and custom conversion definitions</li>
                     </ul>
+                    <p class="text-sm text-blue-800 mt-3">If you connected Meta Ads before this update, reconnect now to grant the new permission scope.</p>
                 </div>
 
                 <button @click="initiateMetaOAuth" :disabled="state.loading" class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">

--- a/frontend/types/IMetaAds.ts
+++ b/frontend/types/IMetaAds.ts
@@ -10,7 +10,9 @@ export enum MetaAdsReportType {
     CAMPAIGNS = 'campaigns',
     ADSETS = 'adsets',
     ADS = 'ads',
-    INSIGHTS = 'insights'
+    INSIGHTS = 'insights',
+    CREATIVES = 'creatives',
+    CUSTOM_CONVERSIONS = 'custom_conversions'
 }
 
 /**
@@ -126,7 +128,7 @@ export interface IMetaSyncConfig {
     name: string;
     adAccountId: string;
     accessToken: string;
-    syncTypes: string[];           // Array of MetaAdsReportType values
+    syncTypes: string[];           // e.g. campaigns/adsets/ads/insights/creatives/custom_conversions
     startDate: string;             // YYYY-MM-DD
     endDate: string;               // YYYY-MM-DD
 }


### PR DESCRIPTION
## Description

feat(meta-ads): add creatives, custom conversions, and UTM attribution fields

Extends the Meta Ads integration with two new sync entities and the attribution-critical url_tags/tracking_specs fields needed for users to reconcile Meta ad spend with UTM-tagged website sessions.

Backend:
- Add ads_management to OAuth scopes (MetaOAuthService)
- Add IMetaAdCreative and IMetaCustomConversion interfaces (IMetaAds.ts)
- Add url_tags and tracking_specs to IMetaAd and IMetaAdCreative
- Implement getCreatives() and getCustomConversions() in MetaAdsService with full pagination support
- Add url_tags and tracking_specs to the ads and adcreatives API field lists
- Extend MetaAdsDriver with syncCreatives(), syncCustomConversions(), table DDL, transform methods, batch upsert, and schema exposure
- Add url_tags (TEXT) and tracking_specs (JSONB) columns to ads and creatives tables
- Update default sync types in MetaAdsProcessor and meta_ads route to include creatives and custom_conversions

Frontend:
- Add CREATIVES and CUSTOM_CONVERSIONS to MetaAdsReportType enum
- Update useMetaAds.getReportTypes() to include new report types
- Update meta-ads connect page: computed reportTypeOptions, updated default selectedReportTypes, ads_management permission note, and reconnect guidance for existing users

Closes #377

## Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [ ] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce and validate the behavior.

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist

Please check all the boxes that apply:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [x] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [ ] I have linked the related issue(s) in the description.

---