### PR TITLE
DRA-297-TICKET-NAV-003-Kill-Orphaned-Pages-Redirect-Deprecate

### DIFF
--- a/frontend/components/DeprecationNotice.vue
+++ b/frontend/components/DeprecationNotice.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+/**
+ * DeprecationNotice — floating banner shown on orphaned pages before auto-redirect.
+ *
+ * Rendered globally via the project layout. Only visible when
+ * `useDeprecationRedirect().state.isActive` is true.
+ *
+ * TICKET NAV-003: Kill Orphaned Pages — Redirect & Deprecate
+ */
+
+const { state, goNow, dismiss } = useDeprecationRedirect();
+
+/** Friendly label derived from the new path's hash fragment */
+const tabLabel = computed(() => {
+    if (!state.newPath) return '';
+    const hash = state.newPath.split('#')[1];
+    if (!hash) return 'Overview';
+    return hash.charAt(0).toUpperCase() + hash.slice(1);
+});
+</script>
+
+<template>
+    <Teleport to="body">
+        <Transition name="deprecation-slide">
+            <div
+                v-if="state.isActive"
+                class="fixed top-0 left-0 right-0 z-[9999] print:hidden"
+                role="alert"
+                aria-live="assertive"
+            >
+                <!-- Banner -->
+                <div class="bg-amber-50 border-b border-amber-300 shadow-lg">
+                    <div class="max-w-7xl mx-auto px-4 py-3 flex items-center gap-3">
+                        <!-- Icon -->
+                        <font-awesome-icon
+                            :icon="['fas', 'triangle-exclamation']"
+                            class="text-amber-600 text-lg flex-shrink-0"
+                        />
+
+                        <!-- Message -->
+                        <p class="text-sm text-amber-900 flex-1">
+                            <span class="font-semibold">This page has moved.</span>
+                            Redirecting to
+                            <span class="font-medium">Intelligence Hub{{ tabLabel ? ` → ${tabLabel}` : '' }}</span>
+                            in a moment&hellip;
+                        </p>
+
+                        <!-- Actions -->
+                        <div class="flex items-center gap-2 flex-shrink-0">
+                            <button
+                                type="button"
+                                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold
+                                       text-amber-900 bg-amber-200 rounded-md hover:bg-amber-300
+                                       transition-colors cursor-pointer"
+                                @click="goNow()"
+                            >
+                                Go now
+                                <font-awesome-icon :icon="['fas', 'arrow-right']" class="text-[10px]" />
+                            </button>
+                            <button
+                                type="button"
+                                class="p-1.5 text-amber-500 hover:text-amber-700 transition-colors cursor-pointer"
+                                aria-label="Dismiss"
+                                @click="dismiss()"
+                            >
+                                <font-awesome-icon :icon="['fas', 'xmark']" class="text-sm" />
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Progress bar (depletes over 2 seconds) -->
+                    <div class="h-0.5 bg-amber-200 overflow-hidden">
+                        <div class="h-full bg-amber-500 deprecation-progress" />
+                    </div>
+                </div>
+            </div>
+        </Transition>
+    </Teleport>
+</template>
+
+<style scoped>
+/* Slide-in from top */
+.deprecation-slide-enter-active {
+    transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+}
+.deprecation-slide-leave-active {
+    transition: transform 0.2s ease-in, opacity 0.2s ease-in;
+}
+.deprecation-slide-enter-from,
+.deprecation-slide-leave-to {
+    transform: translateY(-100%);
+    opacity: 0;
+}
+
+/* Progress bar animation — shrinks from 100% to 0% over 2 seconds */
+.deprecation-progress {
+    width: 100%;
+    animation: deprecation-countdown 2s linear forwards;
+}
+
+@keyframes deprecation-countdown {
+    from {
+        width: 100%;
+    }
+    to {
+        width: 0%;
+    }
+}
+</style>

--- a/frontend/composables/useDeprecationRedirect.ts
+++ b/frontend/composables/useDeprecationRedirect.ts
@@ -1,0 +1,158 @@
+/**
+ * Deprecation Redirect Composable
+ *
+ * Shared reactive state for the orphaned-page redirect system (TICKET NAV-003).
+ *
+ * Usage:
+ *   1. Middleware calls `activate(oldPath, newPath)` when it detects a deprecated route.
+ *   2. The `DeprecationNotice` component reads the reactive state and shows a banner.
+ *   3. After 2 seconds the composable auto-navigates to the new path.
+ *   4. An analytics event is fired on every activation so we can track how many
+ *      users still hit old URLs (informing the decision to delete old pages).
+ */
+
+import { navigateTo } from '#app';
+
+interface DeprecationState {
+    /** Whether a deprecation redirect is currently active */
+    isActive: boolean;
+    /** The old (deprecated) path the user landed on */
+    oldPath: string;
+    /** The new destination path (may include hash fragment) */
+    newPath: string;
+    /** Timestamp when the deprecation was activated */
+    timestamp: string;
+    /** Original query parameters to preserve during redirect */
+    query: Record<string, string | (string | null)[] | null | undefined> | undefined;
+}
+
+const state = reactive<DeprecationState>({
+    isActive: false,
+    oldPath: '',
+    newPath: '',
+    timestamp: '',
+    query: undefined,
+});
+
+let redirectTimer: ReturnType<typeof setTimeout> | null = null;
+
+const REDIRECT_DELAY_MS = 2000;
+
+export function useDeprecationRedirect() {
+    /**
+     * Activate the deprecation notice for a given old → new route pair.
+     *
+     * - Fires a gtag analytics event immediately.
+     * - Starts a 2-second timer that auto-navigates to the new path.
+     * - Preserves the original query parameters.
+     */
+    function activate(
+        oldPath: string,
+        newPath: string,
+        query?: Record<string, string | (string | null)[] | null | undefined>,
+    ) {
+        // Avoid double-activation if middleware re-runs
+        if (state.isActive && state.oldPath === oldPath) return;
+
+        state.isActive = true;
+        state.oldPath = oldPath;
+        state.newPath = newPath;
+        state.timestamp = new Date().toISOString();
+        state.query = query;
+
+        // ── Analytics ───────────────────────────────────────────────────
+        if (import.meta.client) {
+            const gtag = (window as any).gtag;
+            if (typeof gtag === 'function') {
+                gtag('event', 'redirect_deprecated_route', {
+                    old_url: oldPath,
+                    new_url: newPath,
+                    timestamp: state.timestamp,
+                });
+            }
+        }
+
+        // ── Auto-redirect after delay ───────────────────────────────────
+        clearTimer();
+        redirectTimer = setTimeout(() => {
+            navigateWithQuery(newPath, query);
+        }, REDIRECT_DELAY_MS);
+    }
+
+    /**
+     * Immediately navigate to the new path (e.g. user clicks "Go now").
+     * Falls back to the stored query from `activate()` if none is provided.
+     */
+    function goNow(query?: Record<string, string | (string | null)[] | null | undefined>) {
+        clearTimer();
+        navigateWithQuery(state.newPath, query ?? state.query);
+    }
+
+    /**
+     * Dismiss the deprecation banner without redirecting.
+     */
+    function dismiss() {
+        clearTimer();
+        resetState();
+    }
+
+    // ── Internal helpers ────────────────────────────────────────────────
+
+    function clearTimer() {
+        if (redirectTimer !== null) {
+            clearTimeout(redirectTimer);
+            redirectTimer = null;
+        }
+    }
+
+    function resetState() {
+        state.isActive = false;
+        state.oldPath = '';
+        state.newPath = '';
+        state.timestamp = '';
+        state.query = undefined;
+    }
+
+    function navigateWithQuery(
+        target: string,
+        query?: Record<string, string | (string | null)[] | null | undefined>,
+    ) {
+        resetState();
+
+        // Separate hash from path (navigateTo handles hash via the path string)
+        const [pathOnly] = target.split('#');
+
+        // Build final URL — append query params to the path, keep hash in the target
+        if (query && Object.keys(query).length > 0) {
+            const qs = new URLSearchParams();
+            for (const [key, value] of Object.entries(query)) {
+                if (value === null || value === undefined) continue;
+                if (Array.isArray(value)) {
+                    value.forEach((v) => { if (v !== null) qs.append(key, v); });
+                } else {
+                    qs.append(key, value);
+                }
+            }
+            const queryString = qs.toString();
+            if (queryString) {
+                // Reconstruct: path + query + hash
+                const hash = target.includes('#') ? '#' + target.split('#')[1] : '';
+                navigateTo(`${pathOnly}?${queryString}${hash}`);
+                return;
+            }
+        }
+
+        navigateTo(target);
+    }
+
+    return {
+        /** Reactive deprecation state (read by DeprecationNotice component) */
+        state: readonly(state),
+        /** Activate the deprecation redirect flow */
+        activate,
+        /** Navigate immediately without waiting for the timer */
+        goNow,
+        /** Dismiss the banner and cancel the redirect */
+        dismiss,
+    };
+}

--- a/frontend/layouts/project.vue
+++ b/frontend/layouts/project.vue
@@ -67,5 +67,6 @@ const isInInvitationAccept = computed(() => {
         </div>
         <footer-nav class="print:hidden" />
         <cookie-disclaimer-banner class="print:hidden" />
+        <DeprecationNotice />
     </div>
 </template>

--- a/frontend/middleware/00a-redirectOldRoutes.global.ts
+++ b/frontend/middleware/00a-redirectOldRoutes.global.ts
@@ -1,0 +1,95 @@
+/**
+ * Redirect Old Routes Middleware (TICKET NAV-003)
+ *
+ * Intercepts deprecated/orphaned routes and:
+ *   - SSR: issues an immediate HTTP 301 redirect (SEO-friendly)
+ *   - Client: activates a 2-second deprecation banner via `useDeprecationRedirect`,
+ *             then auto-navigates to the new Intelligence Hub location.
+ *
+ * Named with `00a-` prefix so it runs after `00-route-loader` (loading indicator)
+ * but before `01-authorization` (no need to auth-check a redirect).
+ *
+ * Deprecation schedule: these old pages should be deleted 2 sprints after deployment.
+ */
+
+// ─── Redirect Map ──────────────────────────────────────────────────────────
+// Each entry: [patternRegex, newPathBuilder]
+// The regex captures the project ID as group 1 and optionally a sub-ID as group 2.
+
+interface RedirectEntry {
+    /** Regex to test against the route path */
+    pattern: RegExp;
+    /** Build the new path from the regex match groups */
+    buildPath: (projectId: string, subId?: string) => string;
+}
+
+const REDIRECT_MAP: RedirectEntry[] = [
+    // /projects/:id/marketing/attribution → Intelligence Hub #attribution
+    {
+        pattern: /^\/projects\/([^/]+)\/marketing\/attribution\/?$/,
+        buildPath: (pid) => `/projects/${pid}/intelligence#attribution`,
+    },
+    // /projects/:id/marketing/reports → Intelligence Hub #reports
+    {
+        pattern: /^\/projects\/([^/]+)\/marketing\/reports\/?$/,
+        buildPath: (pid) => `/projects/${pid}/intelligence#reports`,
+    },
+    // /projects/:id/marketing/campaigns → Intelligence Hub #campaigns
+    {
+        pattern: /^\/projects\/([^/]+)\/marketing\/campaigns\/?$/,
+        buildPath: (pid) => `/projects/${pid}/intelligence#campaigns`,
+    },
+    // /projects/:id/marketing (exact, no sub-path) → Intelligence Hub #overview
+    {
+        pattern: /^\/projects\/([^/]+)\/marketing\/?$/,
+        buildPath: (pid) => `/projects/${pid}/intelligence`,
+    },
+    // /projects/:id/insights/:insightId → Intelligence Hub #insights
+    {
+        pattern: /^\/projects\/([^/]+)\/insights\/([^/]+)\/?$/,
+        buildPath: (pid, subId) => `/projects/${pid}/intelligence#insights`,
+    },
+    // /projects/:id/insights (exact) → Intelligence Hub #insights
+    {
+        pattern: /^\/projects\/([^/]+)\/insights\/?$/,
+        buildPath: (pid) => `/projects/${pid}/intelligence#insights`,
+    },
+];
+
+/**
+ * Try to match a path against the redirect map.
+ * Returns the new path + project ID if matched, null otherwise.
+ */
+function findRedirect(path: string): { newPath: string; projectId: string } | null {
+    for (const entry of REDIRECT_MAP) {
+        const match = path.match(entry.pattern);
+        if (match) {
+            const projectId = match[1];
+            const subId = match[2]; // may be undefined
+            return {
+                newPath: entry.buildPath(projectId, subId),
+                projectId,
+            };
+        }
+    }
+    return null;
+}
+
+// ─── Middleware ─────────────────────────────────────────────────────────────
+
+export default defineNuxtRouteMiddleware((to) => {
+    const redirect = findRedirect(to.path);
+    if (!redirect) return;
+
+    // ── SSR: immediate 301 redirect for search engines ──────────────────
+    if (import.meta.server) {
+        return navigateTo(redirect.newPath, { redirectCode: 301 });
+    }
+
+    // ── Client: show deprecation banner, then auto-redirect after 2 s ──
+    const { activate } = useDeprecationRedirect();
+    activate(to.path, redirect.newPath, to.query as Record<string, string | (string | null)[] | null | undefined>);
+
+    // Return nothing — allow the current (old) page to render briefly
+    // while the DeprecationNotice banner overlays it.
+});

--- a/frontend/pages/projects/[projectid]/marketing/campaigns/index.vue
+++ b/frontend/pages/projects/[projectid]/marketing/campaigns/index.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+/**
+ * Stub page for deprecated /marketing/campaigns route.
+ *
+ * This route is intercepted by `00a-redirectOldRoutes.global.ts` middleware
+ * and redirected to /intelligence#campaigns. The page exists only so Nuxt
+ * generates a route entry that the middleware can match against.
+ *
+ * TICKET NAV-003: Kill Orphaned Pages — Redirect & Deprecate
+ * Deprecation schedule: delete 2 sprints after deployment.
+ */
+definePageMeta({ layout: 'project' });
+</script>
+
+<template>
+    <!-- Intentionally empty — the middleware redirects before this renders. -->
+    <div />
+</template>


### PR DESCRIPTION
## Description

feat(NAV-003): add deprecation redirect system for orphaned pages
Implement a route-level deprecation and redirect mechanism for old marketing/insights pages that now live under Intelligence Hub.

- Add global middleware (00a-redirectOldRoutes) to intercept deprecated routes and issue SSR 301 redirects or client-side deprecation banners
- Add useDeprecationRedirect composable for shared reactive state, auto-redirect after 2s timer, gtag analytics, and query preservation
- Add DeprecationNotice component with animated banner, progress bar, 'Go now' action, and dismiss option
- Register DeprecationNotice in project layout for global rendering
- Add stub campaigns page so Nuxt generates a route for middleware matching

Deprecated routes redirected to /intelligence#<tab>:
  /marketing/attribution, /marketing/reports, /marketing/campaigns,
  /marketing (exact), /insights/:id, /insights (exact)

## Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [ ] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce and validate the behavior.

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist

Please check all the boxes that apply:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [ ] I have linked the related issue(s) in the description.

---