### PR TITLE
DRA-305-TICKET-MKT-001-Marketing-KPI-Intelligence-Dashboard-Frontend

### DIFF
--- a/frontend/components/intelligence/IntelligenceOverview.vue
+++ b/frontend/components/intelligence/IntelligenceOverview.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
 /**
- * IntelligenceOverview — placeholder shell for the Intelligence Hub "Overview" tab.
+ * IntelligenceOverview — shell for the Intelligence Hub "Overview" tab.
  *
- * This ticket (NAV-004) creates the layout skeleton with placeholder sections:
+ * Sections:
  *   - Header: "Marketing Intelligence" title, date range selector, refresh button
- *   - KPI Summary section      (placeholder — populated in MKT-001)
- *   - Channel Comparison section (placeholder — populated in MKT-003)
- *   - AI Alerts section         (placeholder — populated in MKT-005)
+ *   - KPI Summary section      (Marketing KPI Intelligence Dashboard — live)
+ *   - Channel Comparison section (placeholder — populated in Channel Comparison Table)
+ *   - AI Alerts section         (placeholder — populated in AI-Powered Anomaly Alerts)
  *   - Campaign Summary section  (placeholder — populated in Phase 5)
  *
  * When no data sources are connected, an empty state with CTA is shown instead.
  */
 
 import type { DateRangeValue } from '@/components/intelligence/DateRangeSelector.vue';
+import type { IMarketingHubSummary } from '@/types/marketing-hub';
 
 interface Props {
     /** The project id */
@@ -21,11 +22,14 @@ interface Props {
     hasData: boolean
     /** Whether data is currently loading */
     isLoading: boolean
+    /** Marketing hub summary data (null if not yet loaded) */
+    summary: IMarketingHubSummary | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
     hasData: false,
     isLoading: false,
+    summary: null,
 });
 
 // ── Refresh state ─────────────────────────────────────────────────────────────
@@ -90,31 +94,18 @@ function onRangeChange(range: DateRangeValue) {
             </div>
         </div>
 
-        <!-- ── KPI Summary Section (placeholder) ──────────────────────── -->
+        <!-- ── KPI Summary Section (Marketing KPI Intelligence Dashboard) ── -->
         <section class="bg-white rounded-xl border border-gray-200 p-5">
             <div class="flex items-center gap-2 mb-4">
                 <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center">
                     <font-awesome-icon :icon="['fas', 'chart-pie']" class="text-sm text-blue-400" />
                 </div>
                 <h3 class="text-sm font-semibold text-gray-700">KPI Summary</h3>
-                <span class="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-600 border border-amber-100">
-                    Coming in MKT-001
-                </span>
             </div>
-            <!-- Placeholder skeleton cards -->
-            <div v-if="isLoading" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-                <div v-for="i in 6" :key="i" class="h-20 rounded-lg bg-gray-50 animate-pulse" />
-            </div>
-            <div v-else class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-                <div
-                    v-for="metric in ['ROAS', 'CPA', 'CPL', 'CTR', 'CPC', 'Conv Rate']"
-                    :key="metric"
-                    class="flex flex-col items-center justify-center h-20 rounded-lg bg-gray-50 border border-dashed border-gray-200"
-                >
-                    <span class="text-xs font-medium text-gray-400">{{ metric }}</span>
-                    <span class="text-[10px] text-gray-300 mt-1">—</span>
-                </div>
-            </div>
+            <IntelligenceKpiKpiSummarySection
+                :summary="summary"
+                :is-loading="isLoading"
+            />
         </section>
 
         <!-- ── Channel Comparison Section (placeholder) ──────────────── -->
@@ -125,7 +116,7 @@ function onRangeChange(range: DateRangeValue) {
                 </div>
                 <h3 class="text-sm font-semibold text-gray-700">Channel Comparison</h3>
                 <span class="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-600 border border-amber-100">
-                    Coming in MKT-003
+                    Coming in Channel Comparison Table
                 </span>
             </div>
             <!-- Placeholder table skeleton -->
@@ -164,7 +155,7 @@ function onRangeChange(range: DateRangeValue) {
                 </div>
                 <h3 class="text-sm font-semibold text-gray-700">AI Alerts</h3>
                 <span class="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-600 border border-amber-100">
-                    Coming in MKT-005
+                    Coming in AI-Powered Anomaly Alerts
                 </span>
             </div>
             <div v-if="isLoading" class="space-y-2">

--- a/frontend/components/intelligence/kpi/KPICard.vue
+++ b/frontend/components/intelligence/kpi/KPICard.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+/**
+ * KPICard — Individual marketing KPI metric card.
+ *
+ * Displays a single KPI with its formatted value, trend indicator (up/down/flat),
+ * and a D3.js sparkline showing the weekly trend. Used inside KPISummarySection.
+ */
+
+interface Props {
+    /** Metric label (e.g. "ROAS", "CPA") */
+    label: string;
+    /** Formatted display value (e.g. "4.2x", "$32.50") */
+    value: string;
+    /** Percentage change vs prior period */
+    trend: number;
+    /** Trend direction arrow */
+    trendDirection: 'up' | 'down' | 'flat';
+    /**
+     * Whether the trend is *positive* for this metric.
+     * CPA ↓ is positive; ROAS ↑ is positive.
+     */
+    trendIsPositive: boolean;
+    /** Weekly data points for the sparkline */
+    sparklineData: number[];
+    /** Accent color for sparkline and icon */
+    color?: string;
+    /** FontAwesome icon name (without prefix) */
+    icon?: string;
+    /** Whether data is loading */
+    isLoading?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    color: '#3b82f6',
+    icon: 'chart-line',
+    isLoading: false,
+});
+
+const trendColor = computed(() => {
+    if (props.trendDirection === 'flat') return 'text-gray-400';
+    return props.trendIsPositive
+        ? (props.trendDirection === 'up' ? 'text-emerald-600' : 'text-red-500')
+        : (props.trendDirection === 'up' ? 'text-red-500' : 'text-emerald-600');
+});
+
+const trendBgColor = computed(() => {
+    if (props.trendDirection === 'flat') return 'bg-gray-50 text-gray-400';
+    return props.trendIsPositive
+        ? (props.trendDirection === 'up' ? 'bg-emerald-50 text-emerald-600' : 'bg-red-50 text-red-500')
+        : (props.trendDirection === 'up' ? 'bg-red-50 text-red-500' : 'bg-emerald-50 text-emerald-600');
+});
+
+const trendIcon = computed(() => {
+    if (props.trendDirection === 'flat') return 'minus';
+    return props.trendDirection === 'up' ? 'arrow-up' : 'arrow-down';
+});
+
+const formattedTrend = computed(() => {
+    if (props.trendDirection === 'flat') return '0%';
+    const abs = Math.abs(props.trend);
+    return abs < 0.1 ? '<0.1%' : `${abs.toFixed(1)}%`;
+});
+
+const emit = defineEmits<{
+    (e: 'click'): void;
+}>();
+</script>
+
+<template>
+    <div
+        class="kpi-card group relative bg-white rounded-xl border border-gray-200 p-4 transition-all duration-200 hover:shadow-md hover:border-gray-300 cursor-pointer"
+        @click="emit('click')"
+    >
+        <!-- Loading skeleton -->
+        <template v-if="isLoading">
+            <div class="space-y-3">
+                <div class="h-3 w-16 rounded bg-gray-100 animate-pulse" />
+                <div class="h-6 w-24 rounded bg-gray-100 animate-pulse" />
+                <div class="h-3 w-12 rounded bg-gray-100 animate-pulse" />
+                <div class="h-8 w-full rounded bg-gray-50 animate-pulse" />
+            </div>
+        </template>
+
+        <!-- Loaded content -->
+        <template v-else>
+            <!-- Header: icon + label -->
+            <div class="flex items-center gap-2 mb-2">
+                <div
+                    class="w-6 h-6 rounded-md flex items-center justify-center flex-shrink-0"
+                    :style="{ backgroundColor: `${color}10` }"
+                >
+                    <font-awesome-icon
+                        :icon="['fas', icon]"
+                        class="text-[10px]"
+                        :style="{ color }"
+                    />
+                </div>
+                <span class="text-[11px] font-medium text-gray-500 uppercase tracking-wide">
+                    {{ label }}
+                </span>
+            </div>
+
+            <!-- Value -->
+            <div class="text-xl font-bold text-gray-900 leading-tight mb-1.5">
+                {{ value }}
+            </div>
+
+            <!-- Trend badge -->
+            <div class="flex items-center gap-1.5 mb-3">
+                <span
+                    class="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
+                    :class="trendBgColor"
+                >
+                    <font-awesome-icon :icon="['fas', trendIcon]" class="w-2.5 h-2.5" />
+                    {{ formattedTrend }}
+                </span>
+                <span class="text-[10px] text-gray-400">vs prior</span>
+            </div>
+
+            <!-- Sparkline -->
+            <div v-if="sparklineData.length >= 2" class="mt-auto">
+                <IntelligenceKpiTrendSparkline
+                    :data="sparklineData"
+                    :color="color"
+                    :width="160"
+                    :height="28"
+                />
+            </div>
+            <!-- No data state for sparkline -->
+            <div
+                v-else
+                class="h-7 flex items-center justify-center rounded bg-gray-50 border border-dashed border-gray-200"
+            >
+                <span class="text-[9px] text-gray-300">No trend data</span>
+            </div>
+        </template>
+    </div>
+</template>

--- a/frontend/components/intelligence/kpi/KPISummarySection.vue
+++ b/frontend/components/intelligence/kpi/KPISummarySection.vue
@@ -1,0 +1,267 @@
+<script setup lang="ts">
+/**
+ * KPISummarySection — Container for the 6-card KPI summary row.
+ *
+ * Computes derived KPIs (ROAS, CPA, CPL, CTR, CPC, Conv Rate) from the
+ * marketing hub summary and renders them as KPI cards with sparklines.
+ */
+
+import type { IMarketingHubSummary } from '@/types/marketing-hub';
+
+interface Props {
+    summary: IMarketingHubSummary | null;
+    isLoading?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    isLoading: false,
+});
+
+/** Helper: compute % change between current and prior period */
+function pctChange(current: number, prior: number): number {
+    if (prior === 0) return current > 0 ? 100 : 0;
+    return ((current - prior) / prior) * 100;
+}
+
+/** Helper: determine trend direction */
+function trendDir(val: number): 'up' | 'down' | 'flat' {
+    if (Math.abs(val) < 0.1) return 'flat';
+    return val > 0 ? 'up' : 'down';
+}
+
+/** Extract sparkline data from weekly trend aggregated across all channels */
+function extractSparkline(key: string): number[] {
+    if (!props.summary?.weeklyTrend?.length) return [];
+
+    const weeks = props.summary.weeklyTrend;
+    // Group by weekStart and sum across channels
+    const weekMap = new Map<string, number>();
+
+    for (const point of weeks) {
+        const weekKey = point.weekStart;
+        const current = weekMap.get(weekKey) || 0;
+
+        switch (key) {
+            case 'roas':
+                // ROAS is a ratio — compute per week: sum(pipeline) / sum(spend)
+                weekMap.set(weekKey, current + (point.pipelineValue || 0));
+                break;
+            case 'cpa':
+            case 'spend':
+                weekMap.set(weekKey, current + (point.spend || 0));
+                break;
+            case 'ctr':
+                weekMap.set(weekKey, current + (point.clicks || 0));
+                break;
+            case 'cpc':
+                weekMap.set(weekKey, current + (point.clicks || 0));
+                break;
+            case 'convRate':
+                weekMap.set(weekKey, current + (point.conversions || 0));
+                break;
+            default:
+                weekMap.set(weekKey, current);
+        }
+    }
+
+    const sortedWeeks = Array.from(weekMap.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+    if (key === 'roas') {
+        // For ROAS sparkline, need spend per week too
+        const spendMap = new Map<string, number>();
+        for (const point of weeks) {
+            const current = spendMap.get(point.weekStart) || 0;
+            spendMap.set(point.weekStart, current + (point.spend || 0));
+        }
+        return sortedWeeks.map(([wk, pipeline]) => {
+            const spend = spendMap.get(wk) || 1;
+            return spend > 0 ? pipeline / spend : 0;
+        });
+    }
+
+    if (key === 'ctr') {
+        const imprMap = new Map<string, number>();
+        for (const point of weeks) {
+            const current = imprMap.get(point.weekStart) || 0;
+            imprMap.set(point.weekStart, current + (point.impressions || 0));
+        }
+        return sortedWeeks.map(([wk, clicks]) => {
+            const impr = imprMap.get(wk) || 1;
+            return impr > 0 ? (clicks / impr) * 100 : 0;
+        });
+    }
+
+    if (key === 'cpc') {
+        const spendMap = new Map<string, number>();
+        for (const point of weeks) {
+            const current = spendMap.get(point.weekStart) || 0;
+            spendMap.set(point.weekStart, current + (point.spend || 0));
+        }
+        return sortedWeeks.map(([wk, clicks]) => {
+            const spend = spendMap.get(wk) || 0;
+            return clicks > 0 ? spend / clicks : 0;
+        });
+    }
+
+    if (key === 'convRate') {
+        const clicksMap = new Map<string, number>();
+        for (const point of weeks) {
+            const current = clicksMap.get(point.weekStart) || 0;
+            clicksMap.set(point.weekStart, current + (point.clicks || 0));
+        }
+        return sortedWeeks.map(([wk, convs]) => {
+            const clicks = clicksMap.get(wk) || 1;
+            return clicks > 0 ? (convs / clicks) * 100 : 0;
+        });
+    }
+
+    return sortedWeeks.map(([, val]) => val);
+}
+
+/** Build the 6 KPI definitions from summary data */
+const kpis = computed(() => {
+    if (!props.summary?.totals) return [];
+
+    const t = props.summary.totals;
+    const p = props.summary.priorPeriodTotals;
+
+    // Current period values
+    const roas = t.spend > 0 ? t.pipelineValue / t.spend : 0;
+    const cpa = t.conversions > 0 ? t.spend / t.conversions : 0;
+    const cpl = t.cpl || 0;
+    const ctr = t.impressions > 0 ? (t.clicks / t.impressions) * 100 : 0;
+    const cpc = t.clicks > 0 ? t.spend / t.clicks : 0;
+    const convRate = t.clicks > 0 ? (t.conversions / t.clicks) * 100 : 0;
+
+    // Prior period values
+    let roasPrior = 0;
+    let cpaPrior = 0;
+    let cplPrior = p.cpl || 0;
+    let ctrPrior = 0;
+    let cpcPrior = 0;
+    let convRatePrior = 0;
+
+    if (p) {
+        roasPrior = p.spend > 0 ? p.pipelineValue / p.spend : 0;
+        cpaPrior = p.conversions > 0 ? p.spend / p.conversions : 0;
+        ctrPrior = p.impressions > 0 ? (p.clicks / p.impressions) * 100 : 0;
+        cpcPrior = p.clicks > 0 ? p.spend / p.clicks : 0;
+        convRatePrior = p.clicks > 0 ? (p.conversions / p.clicks) * 100 : 0;
+    }
+
+    return [
+        {
+            label: 'ROAS',
+            value: `${roas.toFixed(1)}x`,
+            trend: pctChange(roas, roasPrior),
+            trendDirection: trendDir(roas - roasPrior),
+            trendIsPositive: true, // ↑ ROAS is good
+            sparklineData: extractSparkline('roas'),
+            color: '#8b5cf6',
+            icon: 'chart-line',
+        },
+        {
+            label: 'CPA',
+            value: `$${cpa.toFixed(2)}`,
+            trend: pctChange(cpa, cpaPrior),
+            trendDirection: trendDir(cpa - cpaPrior),
+            trendIsPositive: false, // ↓ CPA is good
+            sparklineData: extractSparkline('cpa'),
+            color: '#f59e0b',
+            icon: 'dollar-sign',
+        },
+        {
+            label: 'CPL',
+            value: `$${cpl.toFixed(2)}`,
+            trend: pctChange(cpl, cplPrior),
+            trendDirection: trendDir(cpl - cplPrior),
+            trendIsPositive: false, // ↓ CPL is good
+            sparklineData: extractSparkline('cpa'), // CPL uses spend per-week as proxy
+            color: '#ec4899',
+            icon: 'user-plus',
+        },
+        {
+            label: 'CTR',
+            value: `${ctr.toFixed(2)}%`,
+            trend: pctChange(ctr, ctrPrior),
+            trendDirection: trendDir(ctr - ctrPrior),
+            trendIsPositive: true, // ↑ CTR is good
+            sparklineData: extractSparkline('ctr'),
+            color: '#06b6d4',
+            icon: 'mouse-pointer',
+        },
+        {
+            label: 'CPC',
+            value: `$${cpc.toFixed(2)}`,
+            trend: pctChange(cpc, cpcPrior),
+            trendDirection: trendDir(cpc - cpcPrior),
+            trendIsPositive: false, // ↓ CPC is good
+            sparklineData: extractSparkline('cpc'),
+            color: '#f97316',
+            icon: 'hand-pointer',
+        },
+        {
+            label: 'Conv Rate',
+            value: `${convRate.toFixed(2)}%`,
+            trend: pctChange(convRate, convRatePrior),
+            trendDirection: trendDir(convRate - convRatePrior),
+            trendIsPositive: true, // ↑ Conv Rate is good
+            sparklineData: extractSparkline('convRate'),
+            color: '#10b981',
+            icon: 'bullseye',
+        },
+    ];
+});
+
+/** Placeholder KPIs for loading state */
+const loadingKpis = Array.from({ length: 6 }, (_, i) => ({
+    label: '',
+    value: '',
+    trend: 0,
+    trendDirection: 'flat' as const,
+    trendIsPositive: true,
+    sparklineData: [],
+    color: '#d1d5db',
+    icon: 'chart-line',
+    key: `loading-${i}`,
+}));
+</script>
+
+<template>
+    <div>
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+            <!-- Loading skeletons -->
+            <template v-if="isLoading || !summary">
+                <IntelligenceKpiKpiCard
+                    v-for="item in loadingKpis"
+                    :key="item.key"
+                    :label="item.label"
+                    :value="item.value"
+                    :trend="0"
+                    trend-direction="flat"
+                    :trend-is-positive="true"
+                    :sparkline-data="[]"
+                    :color="item.color"
+                    :icon="item.icon"
+                    :is-loading="true"
+                />
+            </template>
+
+            <!-- Loaded KPI cards -->
+            <template v-else>
+                <IntelligenceKpiKpiCard
+                    v-for="(kpi, index) in kpis"
+                    :key="kpi.label"
+                    :label="kpi.label"
+                    :value="kpi.value"
+                    :trend="kpi.trend"
+                    :trend-direction="kpi.trendDirection"
+                    :trend-is-positive="kpi.trendIsPositive"
+                    :sparkline-data="kpi.sparklineData"
+                    :color="kpi.color"
+                    :icon="kpi.icon"
+                />
+            </template>
+        </div>
+    </div>
+</template>

--- a/frontend/components/intelligence/kpi/TrendSparkline.vue
+++ b/frontend/components/intelligence/kpi/TrendSparkline.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+/**
+ * TrendSparkline — Mini D3.js sparkline for KPI cards.
+ *
+ * Renders a smooth area + line chart showing trend data over time.
+ * Uses dynamic D3 import (same pattern as AdminChart.vue).
+ */
+
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
+
+interface Props {
+    /** Array of numeric values to plot */
+    data: number[];
+    /** Stroke/fill color */
+    color?: string;
+    /** Chart width in px */
+    width?: number;
+    /** Chart height in px */
+    height?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    color: '#3b82f6',
+    width: 80,
+    height: 32,
+});
+
+const container = ref<HTMLDivElement | null>(null);
+let cleanup: (() => void) | null = null;
+
+async function render() {
+    if (!import.meta.client || !container.value || !props.data || props.data.length < 2) {
+        return;
+    }
+
+    cleanup?.();
+    cleanup = null;
+    container.value.innerHTML = '';
+
+    const d3 = await import('d3');
+
+    const w = props.width;
+    const h = props.height;
+    const padding = 2;
+
+    const svg = d3
+        .select(container.value)
+        .append('svg')
+        .attr('width', w)
+        .attr('height', h)
+        .attr('viewBox', `0 0 ${w} ${h}`)
+        .style('overflow', 'hidden');
+
+    // Scales
+    const xScale = d3
+        .scaleLinear()
+        .domain([0, props.data.length - 1])
+        .range([padding, w - padding]);
+
+    const yExtent = d3.extent(props.data) as [number, number];
+    const yScale = d3
+        .scaleLinear()
+        .domain([yExtent[0] * 0.9, yExtent[1] * 1.1])
+        .range([h - padding, padding]);
+
+    // Area generator
+    const area = d3.area<number>()
+        .x((_d, i) => xScale(i))
+        .y0(h)
+        .y1((d) => yScale(d))
+        .curve(d3.curveMonotoneX);
+
+    // Line generator
+    const line = d3.line<number>()
+        .x((_d, i) => xScale(i))
+        .y((d) => yScale(d))
+        .curve(d3.curveMonotoneX);
+
+    // Gradient definition
+    const gradientId = `sparkline-grad-${Math.random().toString(36).substring(2, 9)}`;
+    const defs = svg.append('defs');
+    const gradient = defs.append('linearGradient')
+        .attr('id', gradientId)
+        .attr('x1', '0%')
+        .attr('y1', '0%')
+        .attr('x2', '0%')
+        .attr('y2', '100%');
+
+    gradient.append('stop')
+        .attr('offset', '0%')
+        .attr('stop-color', props.color)
+        .attr('stop-opacity', 0.3);
+
+    gradient.append('stop')
+        .attr('offset', '100%')
+        .attr('stop-color', props.color)
+        .attr('stop-opacity', 0.02);
+
+    // Render area fill
+    svg.append('path')
+        .datum(props.data)
+        .attr('fill', `url(#${gradientId})`)
+        .attr('d', area);
+
+    // Render line
+    svg.append('path')
+        .datum(props.data)
+        .attr('fill', 'none')
+        .attr('stroke', props.color)
+        .attr('stroke-width', 1.5)
+        .attr('stroke-linecap', 'round')
+        .attr('stroke-linejoin', 'round')
+        .attr('d', line);
+
+    // End dot (latest value)
+    const lastIdx = props.data.length - 1;
+    svg.append('circle')
+        .attr('cx', xScale(lastIdx))
+        .attr('cy', yScale(props.data[lastIdx]))
+        .attr('r', 2)
+        .attr('fill', props.color);
+
+    cleanup = () => {
+        svg.remove();
+    };
+}
+
+onMounted(() => {
+    if (import.meta.client) render();
+});
+
+watch(
+    () => props.data,
+    () => {
+        if (import.meta.client) render();
+    },
+    { deep: true }
+);
+
+onBeforeUnmount(() => {
+    cleanup?.();
+});
+</script>
+
+<template>
+    <div
+        ref="container"
+        class="inline-block"
+        :style="{ width: `${width}px`, height: `${height}px` }"
+    />
+</template>

--- a/frontend/components/intelligence/kpi/index.ts
+++ b/frontend/components/intelligence/kpi/index.ts
@@ -1,0 +1,3 @@
+export { default as TrendSparkline } from './TrendSparkline.vue';
+export { default as KPICard } from './KPICard.vue';
+export { default as KPISummarySection } from './KPISummarySection.vue';

--- a/frontend/pages/projects/[projectid]/intelligence/index.vue
+++ b/frontend/pages/projects/[projectid]/intelligence/index.vue
@@ -221,6 +221,7 @@ onMounted(async () => {
                         :project-id="Number(projectId)"
                         :has-data="!!hasData"
                         :is-loading="isLoading"
+                        :summary="summary"
                         @refresh="handleRefresh"
                         @update:range="handleRangeChange"
                     />


### PR DESCRIPTION
## Description

feat: add marketing KPI summary section with D3 sparklines to Intelligence Hub

Introduce KPICard, KPISummarySection, and TrendSparkline components to replace the placeholder KPI skeleton in the Intelligence Overview tab. Each KPI card displays a formatted metric value, directional trend badge (up/down/flat with context-aware coloring), and a D3.js sparkline showing weekly trend data with gradient fill.

The 6 core marketing KPIs (ROAS, CPA, CPL, CTR, CPC, Conv Rate) are computed from the marketing hub summary with automatic prior-period comparison. IntelligenceOverview now accepts and passes through a `summary` prop for live data rendering.

## Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [ ] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce and validate the behavior.

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist

Please check all the boxes that apply:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [ ] I have linked the related issue(s) in the description.

---