### PR TITLE
DRA-307-TICKET-MKT-003-Channel-Comparison-Table-Frontend

### DIFF
--- a/frontend/components/intelligence/IntelligenceOverview.vue
+++ b/frontend/components/intelligence/IntelligenceOverview.vue
@@ -14,6 +14,7 @@
 
 import type { DateRangeValue } from '@/components/intelligence/DateRangeSelector.vue';
 import type { IMarketingHubSummary } from '@/types/marketing-hub';
+import type { IChannelRow, ChannelSortKey } from '@/composables/useChannelComparison';
 
 interface Props {
     /** The project id */
@@ -53,6 +54,84 @@ async function handleRefresh() {
 function onRangeChange(range: DateRangeValue) {
     emit('update:range', range);
 }
+
+// ── Channel Comparison logic ─────────────────────────────────────────────────
+const channelSortBy = ref<ChannelSortKey>('spend');
+const channelSortDir = ref<'asc' | 'desc'>('desc');
+
+/** Map summary channels to IChannelRow[] */
+const channelRows = computed<IChannelRow[]>(() => {
+    if (!props.summary?.channels?.length) return [];
+    return props.summary.channels.map(ch => ({
+        channel: ch.channelLabel || ch.channelType || 'Unknown',
+        spend: ch.spend,
+        impressions: ch.impressions,
+        clicks: ch.clicks,
+        conversions: ch.conversions,
+        revenue: ch.pipelineValue,
+        ctr: ch.ctr,
+        cpc: ch.clicks > 0 ? ch.spend / ch.clicks : 0,
+        cpa: ch.cpl,
+        roas: ch.roas,
+    }));
+});
+
+/** Sorted channel rows */
+const sortedChannels = computed<IChannelRow[]>(() => {
+    const rows = [...channelRows.value];
+    const key = channelSortBy.value;
+    const dir = channelSortDir.value === 'asc' ? 1 : -1;
+    return rows.sort((a, b) => ((a[key] ?? 0) - (b[key] ?? 0)) * dir);
+});
+
+/** Aggregated totals row */
+const channelTotals = computed<IChannelRow>(() => {
+    const all = channelRows.value;
+    if (all.length === 0) {
+        return { channel: 'Total', spend: 0, impressions: 0, clicks: 0, conversions: 0, revenue: 0, ctr: 0, cpc: 0, cpa: 0, roas: 0 };
+    }
+    const tSpend = all.reduce((s, c) => s + c.spend, 0);
+    const tImpr = all.reduce((s, c) => s + c.impressions, 0);
+    const tClicks = all.reduce((s, c) => s + c.clicks, 0);
+    const tConv = all.reduce((s, c) => s + c.conversions, 0);
+    const tRev = all.reduce((s, c) => s + c.revenue, 0);
+    return {
+        channel: 'Total',
+        spend: tSpend,
+        impressions: tImpr,
+        clicks: tClicks,
+        conversions: tConv,
+        revenue: tRev,
+        ctr: tImpr > 0 ? (tClicks / tImpr) * 100 : 0,
+        cpc: tClicks > 0 ? tSpend / tClicks : 0,
+        cpa: tConv > 0 ? tSpend / tConv : 0,
+        roas: tSpend > 0 ? tRev / tSpend : 0,
+    };
+});
+
+function toggleChannelSort(key: ChannelSortKey) {
+    if (channelSortBy.value === key) {
+        channelSortDir.value = channelSortDir.value === 'asc' ? 'desc' : 'asc';
+    } else {
+        channelSortBy.value = key;
+        channelSortDir.value = 'desc';
+    }
+}
+
+function fmtCurrency(v: number): string {
+    if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(1)}M`;
+    if (v >= 1_000) return `$${(v / 1_000).toFixed(1)}K`;
+    return `$${v.toFixed(2)}`;
+}
+
+function fmtNumber(v: number): string {
+    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+    if (v >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
+    return v.toLocaleString();
+}
+
+function fmtPercent(v: number): string { return `${v.toFixed(2)}%`; }
+function fmtRatio(v: number): string { return `${v.toFixed(2)}x`; }
 </script>
 
 <template>
@@ -108,43 +187,27 @@ function onRangeChange(range: DateRangeValue) {
             />
         </section>
 
-        <!-- ── Channel Comparison Section (placeholder) ──────────────── -->
+        <!-- ── Channel Comparison Section (MKT-003) ──────────────────── -->
         <section class="bg-white rounded-xl border border-gray-200 p-5">
             <div class="flex items-center gap-2 mb-4">
                 <div class="w-8 h-8 rounded-lg bg-indigo-50 flex items-center justify-center">
                     <font-awesome-icon :icon="['fas', 'chart-bar']" class="text-sm text-indigo-400" />
                 </div>
                 <h3 class="text-sm font-semibold text-gray-700">Channel Comparison</h3>
-                <span class="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-600 border border-amber-100">
-                    Coming in Channel Comparison Table
-                </span>
             </div>
-            <!-- Placeholder table skeleton -->
-            <div v-if="isLoading" class="space-y-2">
-                <div v-for="i in 4" :key="i" class="h-10 rounded bg-gray-50 animate-pulse" />
-            </div>
-            <div v-else class="overflow-hidden rounded-lg border border-dashed border-gray-200">
-                <table class="w-full text-sm">
-                    <thead>
-                        <tr class="bg-gray-50">
-                            <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-400">Channel</th>
-                            <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-400">Spend</th>
-                            <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-400">Clicks</th>
-                            <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-400">CPA</th>
-                            <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-400">ROAS</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr v-for="ch in ['Google Ads', 'Meta Ads', 'LinkedIn Ads']" :key="ch" class="border-t border-gray-100">
-                            <td class="px-4 py-3 text-gray-400">{{ ch }}</td>
-                            <td class="px-4 py-3 text-right text-gray-300">—</td>
-                            <td class="px-4 py-3 text-right text-gray-300">—</td>
-                            <td class="px-4 py-3 text-right text-gray-300">—</td>
-                            <td class="px-4 py-3 text-right text-gray-300">—</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            <IntelligenceChannelChannelComparisonTable
+                :channels="sortedChannels"
+                :totals="channelTotals"
+                :is-loading="isLoading"
+                :has-fetched="!!summary"
+                :sort-by="channelSortBy"
+                :sort-dir="channelSortDir"
+                :toggle-sort="toggleChannelSort"
+                :format-currency="fmtCurrency"
+                :format-number="fmtNumber"
+                :format-percent="fmtPercent"
+                :format-ratio="fmtRatio"
+            />
         </section>
 
         <!-- ── AI Alerts Section (placeholder) ────────────────────────── -->

--- a/frontend/components/intelligence/IntelligenceOverview.vue
+++ b/frontend/components/intelligence/IntelligenceOverview.vue
@@ -14,7 +14,8 @@
 
 import type { DateRangeValue } from '@/components/intelligence/DateRangeSelector.vue';
 import type { IMarketingHubSummary } from '@/types/marketing-hub';
-import type { IChannelRow, ChannelSortKey } from '@/composables/useChannelComparison';
+import type { IChannelRow } from '@/composables/useChannelComparison';
+import { useChannelComparison } from '@/composables/useChannelComparison';
 
 interface Props {
     /** The project id */
@@ -55,9 +56,7 @@ function onRangeChange(range: DateRangeValue) {
     emit('update:range', range);
 }
 
-// ── Channel Comparison logic ─────────────────────────────────────────────────
-const channelSortBy = ref<ChannelSortKey>('spend');
-const channelSortDir = ref<'asc' | 'desc'>('desc');
+// ── Channel Comparison logic (delegated to composable) ──────────────────────
 
 /** Map summary channels to IChannelRow[] */
 const channelRows = computed<IChannelRow[]>(() => {
@@ -76,62 +75,21 @@ const channelRows = computed<IChannelRow[]>(() => {
     }));
 });
 
-/** Sorted channel rows */
-const sortedChannels = computed<IChannelRow[]>(() => {
-    const rows = [...channelRows.value];
-    const key = channelSortBy.value;
-    const dir = channelSortDir.value === 'asc' ? 1 : -1;
-    return rows.sort((a, b) => ((a[key] ?? 0) - (b[key] ?? 0)) * dir);
+const {
+    sortedChannels,
+    totals: channelTotals,
+    sortBy: channelSortBy,
+    sortDir: channelSortDir,
+    toggleSort: toggleChannelSort,
+    hasFetched: channelHasFetched,
+    formatCurrency: fmtCurrency,
+    formatNumber: fmtNumber,
+    formatPercent: fmtPercent,
+    formatRatio: fmtRatio,
+} = useChannelComparison({
+    channelData: channelRows,
+    immediate: false,
 });
-
-/** Aggregated totals row */
-const channelTotals = computed<IChannelRow>(() => {
-    const all = channelRows.value;
-    if (all.length === 0) {
-        return { channel: 'Total', spend: 0, impressions: 0, clicks: 0, conversions: 0, revenue: 0, ctr: 0, cpc: 0, cpa: 0, roas: 0 };
-    }
-    const tSpend = all.reduce((s, c) => s + c.spend, 0);
-    const tImpr = all.reduce((s, c) => s + c.impressions, 0);
-    const tClicks = all.reduce((s, c) => s + c.clicks, 0);
-    const tConv = all.reduce((s, c) => s + c.conversions, 0);
-    const tRev = all.reduce((s, c) => s + c.revenue, 0);
-    return {
-        channel: 'Total',
-        spend: tSpend,
-        impressions: tImpr,
-        clicks: tClicks,
-        conversions: tConv,
-        revenue: tRev,
-        ctr: tImpr > 0 ? (tClicks / tImpr) * 100 : 0,
-        cpc: tClicks > 0 ? tSpend / tClicks : 0,
-        cpa: tConv > 0 ? tSpend / tConv : 0,
-        roas: tSpend > 0 ? tRev / tSpend : 0,
-    };
-});
-
-function toggleChannelSort(key: ChannelSortKey) {
-    if (channelSortBy.value === key) {
-        channelSortDir.value = channelSortDir.value === 'asc' ? 'desc' : 'asc';
-    } else {
-        channelSortBy.value = key;
-        channelSortDir.value = 'desc';
-    }
-}
-
-function fmtCurrency(v: number): string {
-    if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(1)}M`;
-    if (v >= 1_000) return `$${(v / 1_000).toFixed(1)}K`;
-    return `$${v.toFixed(2)}`;
-}
-
-function fmtNumber(v: number): string {
-    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
-    if (v >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
-    return v.toLocaleString();
-}
-
-function fmtPercent(v: number): string { return `${v.toFixed(2)}%`; }
-function fmtRatio(v: number): string { return `${v.toFixed(2)}x`; }
 </script>
 
 <template>
@@ -199,7 +157,7 @@ function fmtRatio(v: number): string { return `${v.toFixed(2)}x`; }
                 :channels="sortedChannels"
                 :totals="channelTotals"
                 :is-loading="isLoading"
-                :has-fetched="!!summary"
+                :has-fetched="channelHasFetched"
                 :sort-by="channelSortBy"
                 :sort-dir="channelSortDir"
                 :toggle-sort="toggleChannelSort"

--- a/frontend/components/intelligence/channel/ChannelComparisonTable.vue
+++ b/frontend/components/intelligence/channel/ChannelComparisonTable.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+/**
+ * ChannelComparisonTable — Cross-channel marketing comparison table.
+ *
+ * Displays per-channel metrics (Spend, CTR, CPA, ROAS) in a sortable,
+ * expandable table. Each row expands to show all 10 KPIs.
+ * Includes:
+ *   - Sortable column headers (default: Spend desc)
+ *   - Total summary bar above the rows
+ *   - Per-channel expandable rows
+ *   - Empty state when no data is available
+ *   - Loading skeletons
+ */
+
+import type { IChannelRow, ChannelSortKey } from '@/composables/useChannelComparison';
+
+interface Props {
+    /** Sorted channel rows */
+    channels: IChannelRow[];
+    /** Total aggregated row */
+    totals: IChannelRow;
+    /** Whether data is loading */
+    isLoading: boolean;
+    /** Whether at least one fetch has completed */
+    hasFetched: boolean;
+    /** Current sort column */
+    sortBy: ChannelSortKey;
+    /** Current sort direction */
+    sortDir: 'asc' | 'desc';
+    /** Sort toggle handler */
+    toggleSort: (key: ChannelSortKey) => void;
+    /** Formatters */
+    formatCurrency: (v: number) => string;
+    formatNumber: (v: number) => string;
+    formatPercent: (v: number) => string;
+    formatRatio: (v: number) => string;
+}
+
+const props = defineProps<Props>();
+
+/** Brand colors for known channels */
+const CHANNEL_COLORS: Record<string, string> = {
+    'google ads': '#4285f4',
+    'google': '#4285f4',
+    'meta ads': '#0668e1',
+    'facebook': '#0668e1',
+    'meta': '#0668e1',
+    'linkedin ads': '#0a66c2',
+    'linkedin': '#0a66c2',
+    'twitter': '#1da1f2',
+    'x': '#1da1f2',
+    'tiktok': '#000000',
+    'instagram': '#e4405f',
+    'email': '#34a853',
+    'klaviyo': '#2e2e2e',
+    'hubspot': '#ff7a59',
+    'organic': '#34a853',
+    'direct': '#fbbc05',
+    'referral': '#ea4335',
+    'other': '#9aa0a6',
+};
+
+/** Fallback color palette for unknown channels */
+const FALLBACK_COLORS = [
+    '#6366f1', '#ec4899', '#f59e0b', '#10b981', '#8b5cf6',
+    '#ef4444', '#06b6d4', '#f97316', '#14b8a6', '#a855f7',
+];
+
+/** Map channel names to colors */
+function getChannelColor(channelName: string, index: number): string {
+    const normalized = channelName.toLowerCase().trim();
+    return CHANNEL_COLORS[normalized] || FALLBACK_COLORS[index % FALLBACK_COLORS.length];
+}
+
+/** Calculate spend share for each channel */
+const spendShares = computed(() => {
+    const totalSpend = props.totals.spend || 1;
+    return props.channels.map(ch => ch.spend / totalSpend);
+});
+
+/** Sortable column definitions */
+interface ColumnDef {
+    key: ChannelSortKey;
+    label: string;
+    align: 'left' | 'right';
+}
+
+const columns: ColumnDef[] = [
+    { key: 'spend', label: 'Spend', align: 'right' },
+    { key: 'impressions', label: 'Impr.', align: 'right' },
+    { key: 'clicks', label: 'Clicks', align: 'right' },
+    { key: 'ctr', label: 'CTR', align: 'right' },
+    { key: 'cpa', label: 'CPA', align: 'right' },
+    { key: 'roas', label: 'ROAS', align: 'right' },
+];
+
+function formatMetric(key: ChannelSortKey, value: number): string {
+    switch (key) {
+        case 'spend':
+        case 'cpc':
+        case 'cpa':
+            return props.formatCurrency(value);
+        case 'impressions':
+        case 'clicks':
+        case 'conversions':
+            return props.formatNumber(value);
+        case 'ctr':
+            return props.formatPercent(value);
+        case 'roas':
+            return props.formatRatio(value);
+        case 'revenue':
+            return props.formatCurrency(value);
+        default:
+            return String(value);
+    }
+}
+</script>
+
+<template>
+    <div class="channel-comparison-table">
+        <!-- Loading skeleton -->
+        <div v-if="isLoading && !hasFetched" class="space-y-2">
+            <div
+                v-for="i in 4"
+                :key="i"
+                class="h-14 rounded-lg bg-gray-50 animate-pulse"
+            />
+        </div>
+
+        <!-- Empty state -->
+        <div
+            v-else-if="!isLoading && channels.length === 0 && hasFetched"
+            class="flex flex-col items-center justify-center py-10 text-center"
+        >
+            <div class="w-12 h-12 rounded-full bg-indigo-50 flex items-center justify-center mb-3">
+                <font-awesome-icon :icon="['fas', 'chart-bar']" class="text-lg text-indigo-300" />
+            </div>
+            <p class="text-sm text-gray-500 font-medium">No channel data available</p>
+            <p class="text-xs text-gray-400 mt-1 max-w-xs">
+                Connect a marketing data source with channel or source grouping to see cross-channel comparisons.
+            </p>
+        </div>
+
+        <!-- Data table -->
+        <template v-else-if="channels.length > 0">
+            <!-- Column header row (sortable) -->
+            <div class="flex items-center gap-3 px-4 py-2 mb-1">
+                <div class="min-w-[140px]">
+                    <span class="text-[10px] font-medium text-gray-400 uppercase tracking-wide">
+                        Channel
+                    </span>
+                </div>
+                <div class="flex-1 max-w-[120px] hidden sm:block" />
+                <div class="flex items-center gap-6 flex-1 justify-end">
+                    <button
+                        v-for="col in columns"
+                        :key="col.key"
+                        type="button"
+                        class="min-w-[70px] text-right group/sort cursor-pointer"
+                        @click="toggleSort(col.key)"
+                    >
+                        <span
+                            class="text-[10px] font-medium uppercase tracking-wide transition-colors"
+                            :class="sortBy === col.key ? 'text-indigo-600' : 'text-gray-400 group-hover/sort:text-gray-500'"
+                        >
+                            {{ col.label }}
+                            <font-awesome-icon
+                                v-if="sortBy === col.key"
+                                :icon="['fas', sortDir === 'asc' ? 'caret-up' : 'caret-down']"
+                                class="ml-0.5 text-[9px]"
+                            />
+                        </span>
+                    </button>
+                </div>
+                <div class="w-3 flex-shrink-0" />
+            </div>
+
+            <!-- Totals summary bar -->
+            <div class="flex items-center gap-3 px-4 py-2.5 bg-gray-50 rounded-lg mb-2 border border-gray-100">
+                <div class="flex items-center gap-2 min-w-[140px]">
+                    <div class="w-2.5 h-2.5 rounded-full bg-gray-400 flex-shrink-0" />
+                    <span class="text-sm font-bold text-gray-700">Total</span>
+                </div>
+                <div class="flex-1 max-w-[120px] hidden sm:block" />
+                <div class="flex items-center gap-6 flex-1 justify-end">
+                    <div
+                        v-for="col in columns"
+                        :key="col.key"
+                        class="text-right min-w-[70px]"
+                    >
+                        <span class="text-sm font-bold text-gray-700">
+                            {{ formatMetric(col.key, totals[col.key]) }}
+                        </span>
+                    </div>
+                </div>
+                <div class="w-3 flex-shrink-0" />
+            </div>
+
+            <!-- Channel rows -->
+            <IntelligenceChannelChannelRowExpandable
+                v-for="(row, idx) in channels"
+                :key="row.channel"
+                :row="row"
+                :color="getChannelColor(row.channel, idx)"
+                :spend-share="spendShares[idx]"
+                :format-currency="formatCurrency"
+                :format-number="formatNumber"
+                :format-percent="formatPercent"
+                :format-ratio="formatRatio"
+            />
+
+            <!-- Sort info line -->
+            <p class="text-[10px] text-gray-300 mt-3 text-right">
+                Sorted by {{ sortBy.toUpperCase() }} · {{ sortDir === 'desc' ? 'highest first' : 'lowest first' }}
+                · {{ channels.length }} {{ channels.length === 1 ? 'channel' : 'channels' }}
+            </p>
+        </template>
+    </div>
+</template>

--- a/frontend/components/intelligence/channel/ChannelRowExpandable.vue
+++ b/frontend/components/intelligence/channel/ChannelRowExpandable.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+/**
+ * ChannelRowExpandable — Single expandable row in the Channel Comparison Table.
+ *
+ * Displays channel name + top-level KPIs in a collapsed row.
+ * On click, expands to show all 10 KPIs in a detail grid.
+ * Also shows a revenue-spend ratio mini-bar visualizing spend share.
+ */
+
+import type { IChannelRow } from '@/composables/useChannelComparison';
+
+interface Props {
+    /** The channel data row */
+    row: IChannelRow;
+    /** Channel brand color */
+    color: string;
+    /** Spend share (0–1) for the ratio bar */
+    spendShare: number;
+    /** Formatters */
+    formatCurrency: (v: number) => string;
+    formatNumber: (v: number) => string;
+    formatPercent: (v: number) => string;
+    formatRatio: (v: number) => string;
+}
+
+const props = defineProps<Props>();
+
+const isExpanded = ref(false);
+
+function toggle() {
+    isExpanded.value = !isExpanded.value;
+}
+
+/** Top-level KPIs shown in collapsed row */
+const topMetrics = computed(() => [
+    { label: 'Spend', value: props.formatCurrency(props.row.spend) },
+    { label: 'Clicks', value: props.formatNumber(props.row.clicks) },
+    { label: 'CPA', value: props.formatCurrency(props.row.cpa) },
+    { label: 'ROAS', value: props.formatRatio(props.row.roas) },
+]);
+
+/** All KPIs shown in expanded detail */
+const allMetrics = computed(() => [
+    { label: 'Spend', value: props.formatCurrency(props.row.spend) },
+    { label: 'Impressions', value: props.formatNumber(props.row.impressions) },
+    { label: 'Clicks', value: props.formatNumber(props.row.clicks) },
+    { label: 'Conversions', value: props.formatNumber(props.row.conversions) },
+    { label: 'Revenue', value: props.formatCurrency(props.row.revenue) },
+    { label: 'CTR', value: props.formatPercent(props.row.ctr) },
+    { label: 'CPC', value: props.formatCurrency(props.row.cpc) },
+    { label: 'CPA', value: props.formatCurrency(props.row.cpa) },
+    { label: 'ROAS', value: props.formatRatio(props.row.roas) },
+]);
+</script>
+
+<template>
+    <div
+        class="channel-row group border border-gray-100 rounded-lg mb-1.5 transition-all duration-200 hover:border-gray-200 hover:shadow-sm cursor-pointer"
+        :class="{ 'border-indigo-200 bg-indigo-50/30 shadow-sm': isExpanded }"
+        @click="toggle"
+    >
+        <!-- Collapsed row -->
+        <div class="flex items-center gap-3 px-4 py-3">
+            <!-- Color dot + channel name -->
+            <div class="flex items-center gap-2 min-w-[140px]">
+                <div
+                    class="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                    :style="{ backgroundColor: color }"
+                />
+                <span class="text-sm font-medium text-gray-800 truncate">
+                    {{ row.channel }}
+                </span>
+            </div>
+
+            <!-- Spend ratio bar -->
+            <div class="flex-1 max-w-[120px] hidden sm:block">
+                <div class="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                    <div
+                        class="h-full rounded-full transition-all duration-300"
+                        :style="{
+                            width: `${Math.max(spendShare * 100, 2)}%`,
+                            backgroundColor: color,
+                        }"
+                    />
+                </div>
+            </div>
+
+            <!-- Top-level metrics -->
+            <div class="flex items-center gap-6 flex-1 justify-end">
+                <div
+                    v-for="metric in topMetrics"
+                    :key="metric.label"
+                    class="text-right min-w-[70px]"
+                >
+                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wide">
+                        {{ metric.label }}
+                    </div>
+                    <div class="text-sm font-semibold text-gray-800">
+                        {{ metric.value }}
+                    </div>
+                </div>
+            </div>
+
+            <!-- Expand chevron -->
+            <font-awesome-icon
+                :icon="['fas', 'chevron-down']"
+                class="w-3 h-3 text-gray-300 transition-transform duration-200 flex-shrink-0"
+                :class="{ 'rotate-180 text-indigo-400': isExpanded }"
+            />
+        </div>
+
+        <!-- Expanded detail grid -->
+        <Transition name="expand">
+            <div
+                v-if="isExpanded"
+                class="px-4 pb-4 pt-1 border-t border-gray-100"
+                @click.stop
+            >
+                <div class="grid grid-cols-3 sm:grid-cols-5 lg:grid-cols-9 gap-3">
+                    <div
+                        v-for="metric in allMetrics"
+                        :key="metric.label"
+                        class="bg-gray-50 rounded-lg px-3 py-2"
+                    >
+                        <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wide mb-0.5">
+                            {{ metric.label }}
+                        </div>
+                        <div class="text-sm font-bold text-gray-800">
+                            {{ metric.value }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Transition>
+    </div>
+</template>
+
+<style scoped>
+.expand-enter-active,
+.expand-leave-active {
+    transition: all 0.2s ease;
+    overflow: hidden;
+}
+
+.expand-enter-from,
+.expand-leave-to {
+    opacity: 0;
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+.expand-enter-to,
+.expand-leave-from {
+    opacity: 1;
+    max-height: 200px;
+}
+</style>

--- a/frontend/components/intelligence/channel/index.ts
+++ b/frontend/components/intelligence/channel/index.ts
@@ -1,0 +1,2 @@
+export { default as ChannelComparisonTable } from './ChannelComparisonTable.vue';
+export { default as ChannelRowExpandable } from './ChannelRowExpandable.vue';

--- a/frontend/composables/useChannelComparison.ts
+++ b/frontend/composables/useChannelComparison.ts
@@ -22,9 +22,13 @@ export interface IChannelRow {
 export type ChannelSortKey = 'spend' | 'impressions' | 'clicks' | 'conversions' | 'ctr' | 'cpc' | 'cpa' | 'roas';
 
 export interface UseChannelComparisonOptions {
-    dataModelId: MaybeRef<number | null>;
-    startDate: MaybeRef<string | null>;
-    endDate: MaybeRef<string | null>;
+    dataModelId?: MaybeRef<number | null>;
+    startDate?: MaybeRef<string | null>;
+    endDate?: MaybeRef<string | null>;
+    /** Pre-loaded channel row data. When provided, the composable uses this
+     *  instead of fetching from the API. Useful for components that already
+     *  have channel data (e.g. from a parent summary response). */
+    channelData?: MaybeRef<IChannelRow[]>;
     /** Default sort column. Defaults to 'spend'. */
     defaultSortBy?: ChannelSortKey;
     /** Default sort direction. Defaults to 'desc'. */
@@ -38,6 +42,7 @@ export function useChannelComparison(options: UseChannelComparisonOptions) {
         dataModelId,
         startDate,
         endDate,
+        channelData,
         defaultSortBy = 'spend',
         defaultSortDir = 'desc',
         immediate = true,
@@ -46,6 +51,18 @@ export function useChannelComparison(options: UseChannelComparisonOptions) {
     const rawChannels = ref<IChannelRow[]>([]);
     const isLoading = ref(false);
     const hasFetched = ref(false);
+
+    // When channelData is provided (pre-loaded), sync it reactively
+    if (channelData) {
+        watch(
+            () => toValue(channelData),
+            (newData) => {
+                rawChannels.value = newData ?? [];
+                hasFetched.value = true;
+            },
+            { immediate: true },
+        );
+    }
 
     const sortBy = ref<ChannelSortKey>(defaultSortBy);
     const sortDir = ref<'asc' | 'desc'>(defaultSortDir);

--- a/frontend/composables/useChannelComparison.ts
+++ b/frontend/composables/useChannelComparison.ts
@@ -1,0 +1,218 @@
+/**
+ * useChannelComparison — Composable for fetching and managing cross-channel
+ * marketing comparison data.
+ *
+ * Calls the backend GET /marketing-metrics/channels endpoint and returns
+ * a sorted, reactive list of IChannelRow items with loading/error state.
+ */
+
+export interface IChannelRow {
+    channel: string;
+    spend: number;
+    impressions: number;
+    clicks: number;
+    conversions: number;
+    revenue: number;
+    ctr: number;
+    cpc: number;
+    cpa: number;
+    roas: number;
+}
+
+export type ChannelSortKey = 'spend' | 'impressions' | 'clicks' | 'conversions' | 'ctr' | 'cpc' | 'cpa' | 'roas';
+
+export interface UseChannelComparisonOptions {
+    dataModelId: MaybeRef<number | null>;
+    startDate: MaybeRef<string | null>;
+    endDate: MaybeRef<string | null>;
+    /** Default sort column. Defaults to 'spend'. */
+    defaultSortBy?: ChannelSortKey;
+    /** Default sort direction. Defaults to 'desc'. */
+    defaultSortDir?: 'asc' | 'desc';
+    /** Whether to auto-fetch on mount. Defaults to true. */
+    immediate?: boolean;
+}
+
+export function useChannelComparison(options: UseChannelComparisonOptions) {
+    const {
+        dataModelId,
+        startDate,
+        endDate,
+        defaultSortBy = 'spend',
+        defaultSortDir = 'desc',
+        immediate = true,
+    } = options;
+
+    const rawChannels = ref<IChannelRow[]>([]);
+    const isLoading = ref(false);
+    const hasFetched = ref(false);
+
+    const sortBy = ref<ChannelSortKey>(defaultSortBy);
+    const sortDir = ref<'asc' | 'desc'>(defaultSortDir);
+
+    /**
+     * Fetch channel comparison data from the API.
+     */
+    async function fetch() {
+        const dmId = toValue(dataModelId);
+        const start = toValue(startDate);
+        const end = toValue(endDate);
+
+        if (!dmId || !start || !end) {
+            rawChannels.value = [];
+            return;
+        }
+
+        isLoading.value = true;
+        try {
+            const { $api } = useNuxtApp();
+            const response = await $api<{
+                success: boolean;
+                data: IChannelRow[];
+            }>('/marketing-metrics/channels', {
+                params: {
+                    dataModelId: dmId,
+                    startDate: start,
+                    endDate: end,
+                },
+            });
+
+            rawChannels.value = response.data || [];
+            hasFetched.value = true;
+        } catch (err) {
+            console.error('[useChannelComparison] Failed to fetch channels:', err);
+            rawChannels.value = [];
+        } finally {
+            isLoading.value = false;
+        }
+    }
+
+    /**
+     * Sorted channels based on current sort key and direction.
+     */
+    const sortedChannels = computed(() => {
+        const channels = [...rawChannels.value];
+        const key = sortBy.value;
+        const dir = sortDir.value === 'asc' ? 1 : -1;
+
+        return channels.sort((a, b) => {
+            const aVal = a[key] ?? 0;
+            const bVal = b[key] ?? 0;
+            return (aVal - bVal) * dir;
+        });
+    });
+
+    /**
+     * Totals row (computed aggregation across all channels).
+     */
+    const totals = computed((): IChannelRow => {
+        const all = rawChannels.value;
+        if (all.length === 0) {
+            return {
+                channel: 'Total',
+                spend: 0,
+                impressions: 0,
+                clicks: 0,
+                conversions: 0,
+                revenue: 0,
+                ctr: 0,
+                cpc: 0,
+                cpa: 0,
+                roas: 0,
+            };
+        }
+
+        const totalSpend = all.reduce((sum, ch) => sum + ch.spend, 0);
+        const totalImpressions = all.reduce((sum, ch) => sum + ch.impressions, 0);
+        const totalClicks = all.reduce((sum, ch) => sum + ch.clicks, 0);
+        const totalConversions = all.reduce((sum, ch) => sum + ch.conversions, 0);
+        const totalRevenue = all.reduce((sum, ch) => sum + ch.revenue, 0);
+
+        return {
+            channel: 'Total',
+            spend: totalSpend,
+            impressions: totalImpressions,
+            clicks: totalClicks,
+            conversions: totalConversions,
+            revenue: totalRevenue,
+            ctr: totalImpressions > 0 ? (totalClicks / totalImpressions) * 100 : 0,
+            cpc: totalClicks > 0 ? totalSpend / totalClicks : 0,
+            cpa: totalConversions > 0 ? totalSpend / totalConversions : 0,
+            roas: totalSpend > 0 ? totalRevenue / totalSpend : 0,
+        };
+    });
+
+    /**
+     * Whether we have any data to display.
+     */
+    const hasData = computed(() => rawChannels.value.length > 0);
+
+    /**
+     * Toggle sort direction or change sort key.
+     */
+    function toggleSort(key: ChannelSortKey) {
+        if (sortBy.value === key) {
+            sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc';
+        } else {
+            sortBy.value = key;
+            sortDir.value = 'desc';
+        }
+    }
+
+    /**
+     * Format a currency value.
+     */
+    function formatCurrency(value: number): string {
+        if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+        if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+        return `$${value.toFixed(2)}`;
+    }
+
+    /**
+     * Format a compact number.
+     */
+    function formatNumber(value: number): string {
+        if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+        if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+        return value.toLocaleString();
+    }
+
+    /**
+     * Format a percentage.
+     */
+    function formatPercent(value: number): string {
+        return `${value.toFixed(2)}%`;
+    }
+
+    /**
+     * Format a ratio (ROAS).
+     */
+    function formatRatio(value: number): string {
+        return `${value.toFixed(2)}x`;
+    }
+
+    // Auto-fetch when dependencies change
+    if (immediate) {
+        watch(
+            [() => toValue(dataModelId), () => toValue(startDate), () => toValue(endDate)],
+            () => { fetch(); },
+            { immediate: true },
+        );
+    }
+
+    return {
+        sortedChannels,
+        totals,
+        isLoading,
+        hasFetched,
+        hasData,
+        sortBy,
+        sortDir,
+        toggleSort,
+        fetch,
+        formatCurrency,
+        formatNumber,
+        formatPercent,
+        formatRatio,
+    };
+}


### PR DESCRIPTION
## Description

feat(intelligence): implement channel comparison table (MKT-003)
Add cross-channel marketing comparison table to the Intelligence Hub:

- New useChannelComparison composable with IChannelRow types, sorting, totals aggregation, formatting utilities, and reactive data fetching
- New ChannelComparisonTable component with sortable columns, brand color mapping, spend share bars, and loading/empty states
- New ChannelRowExpandable component for per-channel expandable rows showing all 10 KPIs
- Replace placeholder skeleton in IntelligenceOverview with live ChannelComparisonTable integration, including channel data mapping, sort toggle logic, and currency/number/percent/ratio formatters
## Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [ ] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce and validate the behavior.

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist

Please check all the boxes that apply:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [ ] I have linked the related issue(s) in the description.


---