### PR TITLE
DRA-315-TICKET-CMP-001-Campaign-Drill-Down-Page-Frontend

### DIFF
--- a/frontend/components/intelligence/IntelligenceOverview.vue
+++ b/frontend/components/intelligence/IntelligenceOverview.vue
@@ -78,6 +78,7 @@ const isRefreshing = ref(false);
 interface Emits {
     (e: 'refresh'): void
     (e: 'update:range', range: DateRangeValue): void
+    (e: 'campaign-click', campaign: any): void
 }
 
 const emit = defineEmits<Emits>();
@@ -283,6 +284,7 @@ function handleToggleAi() {
                 :channels="summary?.channels?.map(ch => ch.channelLabel || ch.channelType || 'Unknown') || []"
                 :max-height="400"
                 :show-filters="true"
+                @campaign-click="emit('campaign-click', $event)"
             />
         </section>
     </div>

--- a/frontend/components/intelligence/campaign/CampaignDrillDown.vue
+++ b/frontend/components/intelligence/campaign/CampaignDrillDown.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+/**
+ * CampaignDrillDown — Main component for the Campaign Drill-Down page (CMP-001).
+ *
+ * Composes CampaignKPICards, CampaignTrendChart, and DimensionBreakdown
+ * into a full campaign performance analysis view.
+ *
+ * Sections:
+ *   - Header: Campaign name, channel badge, date range, status
+ *   - KPIs Row: Spend, Conversions, CPA, ROAS, CTR, CPC with period comparison
+ *   - Daily Trend Chart: Line chart showing spend, conversions, CPA over time
+ *   - Dimension Breakdowns: Tabs for ad group, keyword, device, geo
+ *   - AI Analysis: AI-generated analysis specific to this campaign
+ *   - Recommendations: Actionable suggestions
+ */
+import type { ICampaignPerformanceRow } from '~/composables/useCampaignPerformance';
+import { useCampaignDrillDown } from '~/composables/useCampaignDrillDown';
+import CampaignKPICards from './CampaignKPICards.vue';
+import CampaignTrendChart from './CampaignTrendChart.vue';
+import DimensionBreakdown from './DimensionBreakdown.vue';
+
+interface Props {
+    /** Data model ID to query */
+    dataModelId: number | null;
+    /** Campaign ID from URL */
+    campaignId: string;
+    /** Campaign name (from table row or URL) */
+    campaignName?: string;
+    /** Channel name (from table row or URL) */
+    channel?: string;
+    /** ISO date string — start */
+    startDate: string | null;
+    /** ISO date string — end */
+    endDate: string | null;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    campaignName: '',
+    channel: '',
+});
+
+const emit = defineEmits<{
+    back: [];
+}>();
+
+const {
+    data,
+    isLoading,
+    hasFetched,
+    error,
+    fetch: fetchDrillDown,
+    formatCurrency,
+    formatNumber,
+    formatPercent,
+    formatRatio,
+} = useCampaignDrillDown({
+    dataModelId: computed(() => props.dataModelId),
+    campaignId: computed(() => props.campaignId),
+    startDate: computed(() => props.startDate),
+    endDate: computed(() => props.endDate),
+});
+
+const displayName = computed(() => data.value?.campaignName || props.campaignName || 'Campaign');
+const displayChannel = computed(() => data.value?.channel || props.channel || '');
+const displayStatus = computed(() => data.value?.status || 'active');
+
+function statusClasses(status: string): string {
+    const map: Record<string, string> = {
+        active: 'bg-green-100 text-green-700',
+        paused: 'bg-yellow-100 text-yellow-700',
+        completed: 'bg-blue-100 text-blue-700',
+    };
+    return map[status] ?? 'bg-gray-100 text-gray-600';
+}
+</script>
+
+<template>
+    <div class="campaign-drill-down space-y-6">
+        <!-- ── Header ─────────────────────────────────────────────────── -->
+        <div class="flex items-start justify-between gap-4">
+            <div class="flex-1 min-w-0">
+                <!-- Back button + breadcrumb -->
+                <div class="flex items-center gap-2 mb-2">
+                    <button
+                        type="button"
+                        class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 transition-colors cursor-pointer"
+                        @click="emit('back')"
+                    >
+                        <font-awesome-icon :icon="['fas', 'arrow-left']" class="w-3.5 h-3.5" />
+                        Back to Campaigns
+                    </button>
+                </div>
+
+                <!-- Campaign name + channel badge + status -->
+                <div class="flex items-center gap-3 flex-wrap">
+                    <h1 class="text-xl font-bold text-gray-900 truncate">
+                        {{ displayName }}
+                    </h1>
+                    <span
+                        v-if="displayChannel"
+                        class="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full bg-blue-50 text-blue-700"
+                    >
+                        <font-awesome-icon :icon="['fas', 'chart-bar']" class="w-3 h-3" />
+                        {{ displayChannel }}
+                    </span>
+                    <span
+                        class="inline-flex items-center text-xs font-medium px-2.5 py-0.5 rounded-full"
+                        :class="statusClasses(displayStatus)"
+                    >
+                        {{ displayStatus }}
+                    </span>
+                </div>
+            </div>
+
+            <!-- Refresh button -->
+            <button
+                type="button"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-blue-100 transition-colors cursor-pointer disabled:opacity-50"
+                :disabled="isLoading"
+                @click="fetchDrillDown()"
+            >
+                <font-awesome-icon
+                    :icon="['fas', 'arrow-rotate-right']"
+                    class="w-3.5 h-3.5"
+                    :class="{ 'animate-spin': isLoading }"
+                />
+                Refresh
+            </button>
+        </div>
+
+        <!-- ── Error state ────────────────────────────────────────────── -->
+        <div
+            v-if="error"
+            class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+        >
+            {{ error }}
+        </div>
+
+        <!-- ── KPIs Row ───────────────────────────────────────────────── -->
+        <section>
+            <CampaignKPICards
+                :kpis="data?.kpis ?? null"
+                :deltas="data?.kpiDeltas ?? null"
+                :is-loading="isLoading"
+                :format-currency="formatCurrency"
+                :format-number="formatNumber"
+                :format-percent="formatPercent"
+                :format-ratio="formatRatio"
+            />
+        </section>
+
+        <!-- ── Daily Trend Chart ──────────────────────────────────────── -->
+        <section class="bg-white rounded-xl border border-gray-200 p-5">
+            <div class="flex items-center gap-2 mb-4">
+                <div class="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center">
+                    <font-awesome-icon :icon="['fas', 'chart-line']" class="text-sm text-blue-400" />
+                </div>
+                <h3 class="text-sm font-semibold text-gray-700">Daily Trend</h3>
+            </div>
+            <CampaignTrendChart
+                :data="data?.dailyTrend ?? []"
+                :is-loading="isLoading"
+                :format-currency="formatCurrency"
+                :format-number="formatNumber"
+            />
+        </section>
+
+        <!-- ── Dimension Breakdowns ───────────────────────────────────── -->
+        <section class="bg-white rounded-xl border border-gray-200 p-5">
+            <div class="flex items-center gap-2 mb-4">
+                <div class="w-8 h-8 rounded-lg bg-indigo-50 flex items-center justify-center">
+                    <font-awesome-icon :icon="['fas', 'table']" class="text-sm text-indigo-400" />
+                </div>
+                <h3 class="text-sm font-semibold text-gray-700">Dimension Breakdowns</h3>
+            </div>
+            <DimensionBreakdown
+                :breakdowns="data?.dimensionBreakdowns ?? []"
+                :is-loading="isLoading"
+                :format-currency="formatCurrency"
+                :format-number="formatNumber"
+                :format-percent="formatPercent"
+                :format-ratio="formatRatio"
+            />
+        </section>
+
+        <!-- ── AI Analysis ────────────────────────────────────────────── -->
+        <section class="bg-white rounded-xl border border-gray-200 p-5">
+            <div class="flex items-center gap-2 mb-4">
+                <div class="w-8 h-8 rounded-lg bg-emerald-50 flex items-center justify-center">
+                    <font-awesome-icon :icon="['fas', 'robot']" class="text-sm text-emerald-400" />
+                </div>
+                <h3 class="text-sm font-semibold text-gray-700">AI Analysis</h3>
+            </div>
+
+            <!-- Loading skeleton -->
+            <div v-if="isLoading" class="space-y-2">
+                <div class="h-4 w-full rounded bg-gray-100 animate-pulse" />
+                <div class="h-4 w-5/6 rounded bg-gray-100 animate-pulse" />
+                <div class="h-4 w-4/6 rounded bg-gray-100 animate-pulse" />
+            </div>
+
+            <!-- AI analysis content -->
+            <div
+                v-else-if="data?.aiAnalysis"
+                class="prose prose-sm max-w-none text-gray-600"
+            >
+                <p>{{ data.aiAnalysis }}</p>
+            </div>
+
+            <!-- Empty state -->
+            <div
+                v-else
+                class="flex flex-col items-center justify-center py-8 text-center"
+            >
+                <font-awesome-icon :icon="['fas', 'robot']" class="text-2xl text-gray-300 mb-2" />
+                <p class="text-sm text-gray-400">
+                    {{ hasFetched ? 'No AI analysis available for this campaign' : 'AI analysis will appear once data loads' }}
+                </p>
+            </div>
+        </section>
+
+        <!-- ── Recommendations ────────────────────────────────────────── -->
+        <section
+            v-if="data?.recommendations && data.recommendations.length > 0"
+            class="bg-white rounded-xl border border-gray-200 p-5"
+        >
+            <div class="flex items-center gap-2 mb-4">
+                <div class="w-8 h-8 rounded-lg bg-amber-50 flex items-center justify-center">
+                    <font-awesome-icon :icon="['fas', 'lightbulb']" class="text-sm text-amber-400" />
+                </div>
+                <h3 class="text-sm font-semibold text-gray-700">Recommendations</h3>
+            </div>
+            <ul class="space-y-3">
+                <li
+                    v-for="(rec, idx) in data.recommendations"
+                    :key="idx"
+                    class="flex items-start gap-3 text-sm text-gray-600"
+                >
+                    <span class="flex-shrink-0 w-5 h-5 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center text-[10px] font-bold mt-0.5">
+                        {{ idx + 1 }}
+                    </span>
+                    <span>{{ rec }}</span>
+                </li>
+            </ul>
+        </section>
+    </div>
+</template>

--- a/frontend/components/intelligence/campaign/CampaignKPICards.vue
+++ b/frontend/components/intelligence/campaign/CampaignKPICards.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+/**
+ * CampaignKPICards — Row of KPI metric cards for the Campaign Drill-Down page.
+ *
+ * Displays spend, conversions, CPA, ROAS, CTR, CPC with period comparison deltas.
+ * Uses the same card styling as the existing KPICard component.
+ */
+import type { ICampaignKPIs, ICampaignKPIDelta } from '~/composables/useCampaignDrillDown';
+
+interface Props {
+    kpis: ICampaignKPIs | null;
+    deltas: ICampaignKPIDelta | null;
+    isLoading?: boolean;
+    formatCurrency: (v: number) => string;
+    formatNumber: (v: number) => string;
+    formatPercent: (v: number) => string;
+    formatRatio: (v: number) => string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    kpis: null,
+    deltas: null,
+    isLoading: false,
+});
+
+type KPIDeltaKey = keyof ICampaignKPIDelta;
+
+interface IKPICardDef {
+    key: KPIDeltaKey;
+    label: string;
+    icon: string;
+    color: string;
+    format: 'currency' | 'number' | 'percent' | 'ratio';
+    /** Whether a decrease is positive (e.g. CPA ↓ is good) */
+    lowerIsBetter?: boolean;
+}
+
+const cardDefs: IKPICardDef[] = [
+    { key: 'spend', label: 'Spend', icon: 'dollar-sign', color: '#3b82f6', format: 'currency' },
+    { key: 'conversions', label: 'Conversions', icon: 'check-circle', color: '#10b981', format: 'number' },
+    { key: 'cpa', label: 'CPA', icon: 'tags', color: '#f59e0b', format: 'currency', lowerIsBetter: true },
+    { key: 'roas', label: 'ROAS', icon: 'chart-line', color: '#8b5cf6', format: 'ratio' },
+    { key: 'ctr', label: 'CTR', icon: 'mouse-pointer', color: '#06b6d4', format: 'percent' },
+    { key: 'cpc', label: 'CPC', icon: 'hand-pointer', color: '#ec4899', format: 'currency', lowerIsBetter: true },
+];
+
+function formatValue(value: number, fmt: string, helpers: Props): string {
+    switch (fmt) {
+        case 'currency': return helpers.formatCurrency(value);
+        case 'number': return helpers.formatNumber(value);
+        case 'percent': return helpers.formatPercent(value);
+        case 'ratio': return helpers.formatRatio(value);
+        default: return String(value);
+    }
+}
+
+function getKPIValue(kpis: ICampaignKPIs, key: KPIDeltaKey): number {
+    return kpis[key];
+}
+
+function deltaClass(delta: number | null, lowerIsBetter: boolean): string {
+    if (delta === null) return 'text-gray-400';
+    const isPositive = lowerIsBetter ? delta < 0 : delta > 0;
+    return isPositive ? 'text-emerald-600' : 'text-red-500';
+}
+
+function deltaBgClass(delta: number | null, lowerIsBetter: boolean): string {
+    if (delta === null) return 'bg-gray-50 text-gray-400';
+    const isPositive = lowerIsBetter ? delta < 0 : delta > 0;
+    return isPositive ? 'bg-emerald-50 text-emerald-600' : 'bg-red-50 text-red-500';
+}
+
+function deltaIcon(delta: number | null): string {
+    if (delta === null) return 'minus';
+    return delta >= 0 ? 'arrow-up' : 'arrow-down';
+}
+
+function formatDelta(delta: number | null): string {
+    if (delta === null) return 'N/A';
+    const abs = Math.abs(delta);
+    return abs < 0.001 ? '0%' : `${abs >= 0 ? '+' : ''}${(delta * 100).toFixed(1)}%`;
+}
+</script>
+
+<template>
+    <div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
+        <template v-if="isLoading">
+            <div
+                v-for="i in 6"
+                :key="i"
+                class="rounded-xl border border-gray-200 bg-white p-4 space-y-3"
+            >
+                <div class="h-3 w-16 rounded bg-gray-100 animate-pulse" />
+                <div class="h-6 w-24 rounded bg-gray-100 animate-pulse" />
+                <div class="h-3 w-12 rounded bg-gray-100 animate-pulse" />
+            </div>
+        </template>
+
+        <template v-else-if="kpis">
+            <div
+                v-for="def in cardDefs"
+                :key="def.key"
+                class="rounded-xl border border-gray-200 bg-white p-4 transition-all duration-200 hover:shadow-md hover:border-gray-300"
+            >
+                <!-- Header -->
+                <div class="flex items-center gap-2 mb-2">
+                    <div
+                        class="w-6 h-6 rounded-md flex items-center justify-center flex-shrink-0"
+                        :style="{ backgroundColor: `${def.color}10` }"
+                    >
+                        <font-awesome-icon
+                            :icon="['fas', def.icon]"
+                            class="text-[10px]"
+                            :style="{ color: def.color }"
+                        />
+                    </div>
+                    <span class="text-[11px] font-medium text-gray-500 uppercase tracking-wide">
+                        {{ def.label }}
+                    </span>
+                </div>
+
+                <!-- Value -->
+                <div class="text-xl font-bold text-gray-900 leading-tight mb-1.5">
+                    {{ formatValue(getKPIValue(kpis, def.key), def.format, props) }}
+                </div>
+
+                <!-- Delta badge -->
+                <div v-if="deltas" class="flex items-center gap-1.5">
+                    <span
+                        class="inline-flex items-center gap-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
+                        :class="deltaBgClass(deltas[def.key], !!def.lowerIsBetter)"
+                    >
+                        <font-awesome-icon
+                            :icon="['fas', deltaIcon(deltas[def.key])]"
+                            class="w-2.5 h-2.5"
+                        />
+                        {{ formatDelta(deltas[def.key]) }}
+                    </span>
+                    <span class="text-[10px] text-gray-400">vs prior</span>
+                </div>
+                <div v-else class="text-[10px] text-gray-400">No prior period data</div>
+            </div>
+        </template>
+    </div>
+</template>

--- a/frontend/components/intelligence/campaign/CampaignTrendChart.vue
+++ b/frontend/components/intelligence/campaign/CampaignTrendChart.vue
@@ -1,0 +1,272 @@
+<script setup lang="ts">
+/**
+ * CampaignTrendChart — Dual Y-axis line chart showing daily spend,
+ * conversions, and CPA over time for a single campaign.
+ *
+ * Uses D3.js (same pattern as TrendSparkline).
+ */
+import type { IDailyTrendPoint } from '~/composables/useCampaignDrillDown';
+
+interface Props {
+    data: IDailyTrendPoint[];
+    isLoading?: boolean;
+    formatCurrency: (v: number) => string;
+    formatNumber: (v: number) => string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    isLoading: false,
+});
+
+const container = ref<HTMLDivElement | null>(null);
+let cleanup: (() => void) | null = null;
+let resizeObserver: ResizeObserver | null = null;
+
+const activeMetrics = ref<Set<'spend' | 'conversions' | 'cpa'>>(new Set(['spend', 'conversions']));
+
+const metricConfig = {
+    spend: { label: 'Spend', color: '#3b82f6', axis: 'left' as const },
+    conversions: { label: 'Conversions', color: '#10b981', axis: 'right' as const },
+    cpa: { label: 'CPA', color: '#f59e0b', axis: 'left' as const },
+};
+
+function toggleMetric(metric: 'spend' | 'conversions' | 'cpa') {
+    if (activeMetrics.value.has(metric)) {
+        if (activeMetrics.value.size > 1) {
+            activeMetrics.value.delete(metric);
+        }
+    } else {
+        activeMetrics.value.add(metric);
+    }
+    activeMetrics.value = new Set(activeMetrics.value);
+    if (import.meta.client) render();
+}
+
+async function render() {
+    if (!import.meta.client || !container.value || !props.data || props.data.length < 2) {
+        return;
+    }
+
+    cleanup?.();
+    cleanup = null;
+    container.value.innerHTML = '';
+
+    const d3 = await import('d3');
+
+    const margin = { top: 20, right: 60, bottom: 40, left: 60 };
+    const w = container.value.clientWidth || 600;
+    const h = 300;
+    const innerW = w - margin.left - margin.right;
+    const innerH = h - margin.top - margin.bottom;
+
+    const svg = d3
+        .select(container.value)
+        .append('svg')
+        .attr('width', w)
+        .attr('height', h)
+        .attr('viewBox', `0 0 ${w} ${h}`);
+
+    const g = svg.append('g')
+        .attr('transform', `translate(${margin.left},${margin.top})`);
+
+    // X scale — dates
+    const parseDate = d3.timeParse('%Y-%m-%d');
+    const dates = props.data.map(d => parseDate(d.date)!).filter(Boolean);
+    const xScale = d3.scaleTime()
+        .domain(d3.extent(dates) as [Date, Date])
+        .range([0, innerW]);
+
+    // Determine which metrics are active
+    const metricsToShow = Array.from(activeMetrics.value);
+    const leftMetrics = metricsToShow.filter(m => metricConfig[m].axis === 'left');
+    const rightMetrics = metricsToShow.filter(m => metricConfig[m].axis === 'right');
+
+    // Left Y scale
+    if (leftMetrics.length > 0) {
+        const allLeftValues = leftMetrics.flatMap(m => props.data.map(d => d[m]));
+        const leftExtent = d3.extent(allLeftValues) as [number, number];
+        const yLeft = d3.scaleLinear()
+            .domain([0, leftExtent[1] * 1.1 || 1])
+            .range([innerH, 0]);
+
+        // Left axis
+        g.append('g')
+            .call(d3.axisLeft(yLeft).ticks(5).tickFormat((d) => {
+                const val = Number(d);
+                if (leftMetrics.includes('spend')) {
+                    return props.formatCurrency(val);
+                }
+                return val.toLocaleString();
+            }))
+            .selectAll('text')
+            .style('font-size', '10px')
+            .style('fill', '#6b7280');
+
+        // Grid lines
+        g.append('g')
+            .attr('class', 'grid')
+            .call(d3.axisLeft(yLeft).ticks(5).tickSize(-innerW).tickFormat(null as any))
+            .selectAll('line')
+            .style('stroke', '#f3f4f6')
+            .style('stroke-dasharray', '3,3');
+
+        g.selectAll('.grid .domain').remove();
+
+        // Lines for left metrics
+        for (const metric of leftMetrics) {
+            const line = d3.line<IDailyTrendPoint>()
+                .x(d => xScale(parseDate(d.date)!))
+                .y(d => yLeft(d[metric]))
+                .curve(d3.curveMonotoneX);
+
+            g.append('path')
+                .datum(props.data)
+                .attr('fill', 'none')
+                .attr('stroke', metricConfig[metric].color)
+                .attr('stroke-width', 2)
+                .attr('stroke-linecap', 'round')
+                .attr('d', line);
+
+            // Dots
+            g.selectAll(`.dot-${metric}`)
+                .data(props.data)
+                .enter()
+                .append('circle')
+                .attr('cx', d => xScale(parseDate(d.date)!))
+                .attr('cy', d => yLeft(d[metric]))
+                .attr('r', 3)
+                .attr('fill', metricConfig[metric].color)
+                .attr('stroke', 'white')
+                .attr('stroke-width', 1.5);
+        }
+    }
+
+    // Right Y scale
+    if (rightMetrics.length > 0) {
+        const allRightValues = rightMetrics.flatMap(m => props.data.map(d => d[m]));
+        const rightExtent = d3.extent(allRightValues) as [number, number];
+        const yRight = d3.scaleLinear()
+            .domain([0, rightExtent[1] * 1.1 || 1])
+            .range([innerH, 0]);
+
+        g.append('g')
+            .attr('transform', `translate(${innerW},0)`)
+            .call(d3.axisRight(yRight).ticks(5).tickFormat((d) => {
+                return Number(d).toLocaleString();
+            }))
+            .selectAll('text')
+            .style('font-size', '10px')
+            .style('fill', '#6b7280');
+
+        for (const metric of rightMetrics) {
+            const line = d3.line<IDailyTrendPoint>()
+                .x(d => xScale(parseDate(d.date)!))
+                .y(d => yRight(d[metric]))
+                .curve(d3.curveMonotoneX);
+
+            g.append('path')
+                .datum(props.data)
+                .attr('fill', 'none')
+                .attr('stroke', metricConfig[metric].color)
+                .attr('stroke-width', 2)
+                .attr('stroke-linecap', 'round')
+                .attr('stroke-dasharray', '6,3')
+                .attr('d', line);
+
+            g.selectAll(`.dot-${metric}`)
+                .data(props.data)
+                .enter()
+                .append('circle')
+                .attr('cx', d => xScale(parseDate(d.date)!))
+                .attr('cy', d => yRight(d[metric]))
+                .attr('r', 3)
+                .attr('fill', metricConfig[metric].color)
+                .attr('stroke', 'white')
+                .attr('stroke-width', 1.5);
+        }
+    }
+
+    // X axis
+    g.append('g')
+        .attr('transform', `translate(0,${innerH})`)
+        .call(d3.axisBottom(xScale).ticks(6).tickFormat(d3.timeFormat('%b %d') as any))
+        .selectAll('text')
+        .style('font-size', '10px')
+        .style('fill', '#6b7280');
+
+    // Remove domain lines for cleaner look
+    g.selectAll('.domain').style('stroke', '#e5e7eb');
+
+    cleanup = () => {
+        svg.remove();
+    };
+}
+
+onMounted(() => {
+    if (import.meta.client) {
+        render();
+        if (container.value) {
+            resizeObserver = new ResizeObserver(() => render());
+            resizeObserver.observe(container.value);
+        }
+    }
+});
+
+watch(
+    () => props.data,
+    () => { if (import.meta.client) render(); },
+    { deep: true },
+);
+
+onBeforeUnmount(() => {
+    resizeObserver?.disconnect();
+    cleanup?.();
+});
+</script>
+
+<template>
+    <div class="space-y-3">
+        <!-- Metric toggle buttons -->
+        <div class="flex items-center gap-2 flex-wrap">
+            <button
+                v-for="(config, metric) in metricConfig"
+                :key="metric"
+                type="button"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border transition-colors cursor-pointer"
+                :class="
+                    activeMetrics.has(metric as any)
+                        ? 'border-transparent text-white'
+                        : 'border-gray-200 text-gray-500 bg-white hover:bg-gray-50'
+                "
+                :style="activeMetrics.has(metric as any) ? { backgroundColor: config.color } : {}"
+                @click="toggleMetric(metric as any)"
+            >
+                <span
+                    class="w-2 h-2 rounded-full"
+                    :style="{ backgroundColor: activeMetrics.has(metric as any) ? 'white' : config.color }"
+                />
+                {{ config.label }}
+            </button>
+        </div>
+
+        <!-- Loading skeleton -->
+        <div v-if="isLoading" class="h-[300px] rounded-lg bg-gray-50 animate-pulse" />
+
+        <!-- Empty state -->
+        <div
+            v-else-if="!data || data.length < 2"
+            class="h-[300px] flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-200 bg-gray-50"
+        >
+            <font-awesome-icon :icon="['fas', 'chart-line']" class="text-3xl text-gray-300 mb-2" />
+            <p class="text-sm text-gray-400">No trend data available</p>
+        </div>
+
+        <!-- Chart container -->
+        <div
+            v-else
+            ref="container"
+            class="w-full"
+            style="height: 300px;"
+        />
+    </div>
+</template>

--- a/frontend/components/intelligence/campaign/DimensionBreakdown.vue
+++ b/frontend/components/intelligence/campaign/DimensionBreakdown.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+/**
+ * DimensionBreakdown — Tabbed dimension breakdowns for the Campaign Drill-Down page.
+ *
+ * Shows Ad Group, Keyword, Device, and Geographic performance tables
+ * with sorting and performance scoring.
+ */
+import type { IDimensionBreakdown, IDimensionRow } from '~/composables/useCampaignDrillDown';
+
+interface Props {
+    breakdowns: IDimensionBreakdown[];
+    isLoading?: boolean;
+    formatCurrency: (v: number) => string;
+    formatNumber: (v: number) => string;
+    formatPercent: (v: number) => string;
+    formatRatio: (v: number) => string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    isLoading: false,
+});
+
+const activeDimension = ref(0);
+type SortKey = 'name' | 'spend' | 'impressions' | 'clicks' | 'conversions' | 'ctr' | 'cpc' | 'cpa' | 'roas' | 'score';
+const sortBy = ref<SortKey>('spend');
+const sortDir = ref<'asc' | 'desc'>('desc');
+
+function toggleSort(key: SortKey) {
+    if (sortBy.value === key) {
+        sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc';
+    } else {
+        sortBy.value = key;
+        sortDir.value = 'desc';
+    }
+}
+
+const sortedRows = computed(() => {
+    const breakdown = props.breakdowns[activeDimension.value];
+    if (!breakdown) return [];
+    const rows = [...breakdown.rows];
+    const dir = sortDir.value === 'asc' ? 1 : -1;
+    return rows.sort((a, b) => {
+        const aVal = a[sortBy.value] ?? 0;
+        const bVal = b[sortBy.value] ?? 0;
+        if (typeof aVal === 'string' && typeof bVal === 'string') {
+            return aVal.localeCompare(bVal) * dir;
+        }
+        return ((aVal as number) - (bVal as number)) * dir;
+    });
+});
+
+function scoreColor(score: number): string {
+    if (score >= 80) return 'bg-emerald-100 text-emerald-700';
+    if (score >= 60) return 'bg-blue-100 text-blue-700';
+    if (score >= 40) return 'bg-amber-100 text-amber-700';
+    return 'bg-red-100 text-red-700';
+}
+
+function scoreLabel(score: number): string {
+    if (score >= 80) return 'Top';
+    if (score >= 60) return 'Good';
+    if (score >= 40) return 'Fair';
+    return 'Low';
+}
+
+const dimensionIcons: Record<string, string> = {
+    'Ad Group': 'layer-group',
+    'Keyword': 'key',
+    'Device': 'laptop',
+    'Geographic': 'globe',
+};
+
+// Reset sort when switching tabs
+watch(activeDimension, () => {
+    sortBy.value = 'spend';
+    sortDir.value = 'desc';
+});
+</script>
+
+<template>
+    <div class="space-y-4">
+        <!-- Loading skeleton -->
+        <template v-if="isLoading">
+            <div class="flex gap-2">
+                <div v-for="i in 4" :key="i" class="h-9 w-24 rounded-lg bg-gray-100 animate-pulse" />
+            </div>
+            <div class="h-48 rounded-lg bg-gray-50 animate-pulse" />
+        </template>
+
+        <!-- Empty state -->
+        <div
+            v-else-if="!breakdowns || breakdowns.length === 0"
+            class="flex flex-col items-center justify-center py-16 rounded-lg border border-dashed border-gray-200 bg-gray-50"
+        >
+            <font-awesome-icon :icon="['fas', 'table']" class="text-3xl text-gray-300 mb-2" />
+            <p class="text-sm text-gray-400">No dimension breakdowns available</p>
+            <p class="text-xs text-gray-300 mt-1">This campaign may not have ad group, keyword, or geo data</p>
+        </div>
+
+        <template v-else>
+            <!-- Dimension tabs -->
+            <div class="flex items-center gap-1 overflow-x-auto pb-1">
+                <button
+                    v-for="(breakdown, idx) in breakdowns"
+                    :key="breakdown.dimension"
+                    type="button"
+                    class="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border transition-colors cursor-pointer whitespace-nowrap"
+                    :class="
+                        activeDimension === idx
+                            ? 'border-primary-blue-100 bg-blue-50 text-primary-blue-100'
+                            : 'border-gray-200 bg-white text-gray-500 hover:bg-gray-50'
+                    "
+                    @click="activeDimension = idx"
+                >
+                    <font-awesome-icon
+                        :icon="['fas', dimensionIcons[breakdown.label] || 'table']"
+                        class="text-xs"
+                    />
+                    {{ breakdown.label }}
+                    <span
+                        class="text-[10px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-500"
+                        :class="activeDimension === idx ? 'bg-blue-100 text-blue-600' : ''"
+                    >
+                        {{ breakdown.rows.length }}
+                    </span>
+                </button>
+            </div>
+
+            <!-- Table -->
+            <div
+                v-if="sortedRows.length > 0"
+                class="overflow-hidden rounded-xl border border-gray-200 bg-white"
+            >
+                <div class="overflow-x-auto max-h-[400px]">
+                    <table class="w-full text-sm">
+                        <thead class="sticky top-0 z-10 border-b border-gray-200 bg-gray-50/95 backdrop-blur">
+                            <tr>
+                                <th
+                                    class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 cursor-pointer select-none hover:text-gray-700"
+                                    @click="toggleSort('name')"
+                                >
+                                    <span class="inline-flex items-center gap-1">
+                                        {{ breakdowns[activeDimension]?.label || 'Name' }}
+                                        <svg
+                                            :class="['h-3 w-3 text-gray-400 transition-transform', sortBy === 'name' ? (sortDir === 'asc' ? 'rotate-180' : '') : 'opacity-0']"
+                                            fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                                        >
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                                        </svg>
+                                    </span>
+                                </th>
+                                <th class="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Score</th>
+                                <th
+                                    v-for="col in [
+                                        { key: 'spend' as SortKey, label: 'Spend' },
+                                        { key: 'impressions' as SortKey, label: 'Impressions' },
+                                        { key: 'clicks' as SortKey, label: 'Clicks' },
+                                        { key: 'conversions' as SortKey, label: 'Conv' },
+                                        { key: 'ctr' as SortKey, label: 'CTR' },
+                                        { key: 'cpc' as SortKey, label: 'CPC' },
+                                        { key: 'cpa' as SortKey, label: 'CPA' },
+                                        { key: 'roas' as SortKey, label: 'ROAS' },
+                                    ]"
+                                    :key="col.key"
+                                    class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 cursor-pointer select-none hover:text-gray-700"
+                                    @click="toggleSort(col.key)"
+                                >
+                                    <span class="inline-flex items-center gap-1 justify-end">
+                                        {{ col.label }}
+                                        <svg
+                                            :class="['h-3 w-3 text-gray-400 transition-transform', sortBy === col.key ? (sortDir === 'asc' ? 'rotate-180' : '') : 'opacity-0']"
+                                            fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                                        >
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                                        </svg>
+                                    </span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100">
+                            <tr
+                                v-for="row in sortedRows"
+                                :key="row.name"
+                                class="transition-colors hover:bg-gray-50"
+                            >
+                                <td class="px-4 py-3 font-medium text-gray-900 max-w-[200px] truncate">
+                                    {{ row.name }}
+                                </td>
+                                <td class="px-4 py-3">
+                                    <span
+                                        class="inline-flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full"
+                                        :class="scoreColor(row.score)"
+                                    >
+                                        {{ row.score }} — {{ scoreLabel(row.score) }}
+                                    </span>
+                                </td>
+                                <td class="px-4 py-3 text-right tabular-nums text-gray-900">
+                                    {{ formatCurrency(row.spend) }}
+                                </td>
+                                <td class="px-4 py-3 text-right tabular-nums text-gray-600">
+                                    {{ formatNumber(row.impressions) }}
+                                </td>
+                                <td class="px-4 py-3 text-right tabular-nums text-gray-600">
+                                    {{ formatNumber(row.clicks) }}
+                                </td>
+                                <td class="px-4 py-3 text-right tabular-nums text-gray-600">
+                                    {{ formatNumber(row.conversions) }}
+                                </td>
+                                <td class="px-4 py-3 text-right tabular-nums text-gray-600">
+                                    {{ formatPercent(row.ctr) }}
+                                </td>
+                                <td class="px-4 py-3 text-right tabular-nums text-gray-600">
+                                    {{ formatCurrency(row.cpc) }}
+                                </td>
+                                <td class="px-4 py-3 text-right tabular-nums text-gray-600">
+                                    {{ formatCurrency(row.cpa) }}
+                                </td>
+                                <td
+                                    :class="[
+                                        'px-4 py-3 text-right tabular-nums font-medium',
+                                        row.roas >= 3 ? 'text-emerald-600' : '',
+                                        row.roas >= 1 && row.roas < 3 ? 'text-blue-600' : '',
+                                        row.roas >= 0.5 && row.roas < 1 ? 'text-amber-600' : '',
+                                        row.roas < 0.5 ? 'text-red-600' : '',
+                                    ]"
+                                >
+                                    {{ formatRatio(row.roas) }}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <!-- No rows for this dimension -->
+            <div
+                v-else
+                class="flex flex-col items-center justify-center py-12 rounded-lg border border-dashed border-gray-200 bg-gray-50"
+            >
+                <p class="text-sm text-gray-400">No data for {{ breakdowns[activeDimension]?.label }}</p>
+            </div>
+        </template>
+    </div>
+</template>

--- a/frontend/components/intelligence/campaign/index.ts
+++ b/frontend/components/intelligence/campaign/index.ts
@@ -8,3 +8,7 @@
 export { default as CampaignPerformanceTable } from './CampaignPerformanceTable.vue';
 export { default as CampaignStatusBadge } from './CampaignStatusBadge.vue';
 export { default as CampaignFilters } from './CampaignFilters.vue';
+export { default as CampaignDrillDown } from './CampaignDrillDown.vue';
+export { default as CampaignKPICards } from './CampaignKPICards.vue';
+export { default as CampaignTrendChart } from './CampaignTrendChart.vue';
+export { default as DimensionBreakdown } from './DimensionBreakdown.vue';

--- a/frontend/composables/useCampaignDrillDown.ts
+++ b/frontend/composables/useCampaignDrillDown.ts
@@ -1,0 +1,181 @@
+/**
+ * useCampaignDrillDown — Composable for fetching detailed campaign-level
+ * analysis data for the Campaign Drill-Down Page (CMP-001).
+ *
+ * Calls the campaign analysis endpoint and provides reactive KPIs,
+ * daily trend data, dimension breakdowns, and AI analysis.
+ */
+import { useAppFetch } from '@/composables/useAppFetch';
+import { baseUrl } from '~/composables/Utils';
+import { getAuthToken } from '~/composables/AuthToken';
+
+export interface ICampaignKPIs {
+    spend: number;
+    conversions: number;
+    cpa: number;
+    roas: number;
+    ctr: number;
+    cpc: number;
+    impressions: number;
+    clicks: number;
+    revenue: number;
+}
+
+export interface ICampaignKPIDelta {
+    spend: number | null;
+    conversions: number | null;
+    cpa: number | null;
+    roas: number | null;
+    ctr: number | null;
+    cpc: number | null;
+}
+
+export interface IDailyTrendPoint {
+    date: string;
+    spend: number;
+    conversions: number;
+    cpa: number;
+}
+
+export interface IDimensionRow {
+    name: string;
+    spend: number;
+    impressions: number;
+    clicks: number;
+    conversions: number;
+    ctr: number;
+    cpc: number;
+    cpa: number;
+    roas: number;
+    score: number;
+}
+
+export interface IDimensionBreakdown {
+    dimension: string;
+    label: string;
+    rows: IDimensionRow[];
+}
+
+export interface ICampaignDrillDownData {
+    campaignId: string;
+    campaignName: string;
+    channel: string;
+    status: string;
+    kpis: ICampaignKPIs;
+    kpiDeltas: ICampaignKPIDelta;
+    dailyTrend: IDailyTrendPoint[];
+    dimensionBreakdowns: IDimensionBreakdown[];
+    aiAnalysis: string | null;
+    recommendations: string[];
+}
+
+export interface UseCampaignDrillDownOptions {
+    dataModelId?: MaybeRef<number | null>;
+    campaignId?: MaybeRef<string | null>;
+    startDate?: MaybeRef<string | null>;
+    endDate?: MaybeRef<string | null>;
+}
+
+export function useCampaignDrillDown(options: UseCampaignDrillDownOptions) {
+    const {
+        dataModelId,
+        campaignId,
+        startDate,
+        endDate,
+    } = options;
+
+    const data = ref<ICampaignDrillDownData | null>(null);
+    const isLoading = ref(false);
+    const hasFetched = ref(false);
+    const error = ref<string | null>(null);
+
+    async function fetch() {
+        const dmId = toValue(dataModelId);
+        const cId = toValue(campaignId);
+        const start = toValue(startDate);
+        const end = toValue(endDate);
+
+        if (!dmId || !cId || !start || !end) {
+            data.value = null;
+            return;
+        }
+
+        isLoading.value = true;
+        error.value = null;
+        try {
+            const token = getAuthToken();
+            if (!token) {
+                data.value = null;
+                return;
+            }
+            const params = new URLSearchParams({
+                dataModelId: String(dmId),
+                startDate: start,
+                endDate: end,
+            }).toString();
+            const url = `${baseUrl()}/campaigns/${cId}/analysis?${params}`;
+            const response = await useAppFetch<{
+                success: boolean;
+                data: ICampaignDrillDownData;
+            }>(url, {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Authorization-Type': 'auth',
+                },
+            });
+
+            data.value = response?.data ?? null;
+            hasFetched.value = true;
+        } catch (err: any) {
+            error.value = err?.message || 'Failed to load campaign analysis';
+            data.value = null;
+        } finally {
+            isLoading.value = false;
+        }
+    }
+
+    // Formatting helpers
+    function formatCurrency(value: number): string {
+        if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+        if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+        return `$${value.toFixed(2)}`;
+    }
+
+    function formatNumber(value: number): string {
+        if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+        if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+        return value.toLocaleString();
+    }
+
+    function formatPercent(value: number): string {
+        return `${value.toFixed(2)}%`;
+    }
+
+    function formatRatio(value: number): string {
+        return `${value.toFixed(2)}x`;
+    }
+
+    // Auto-fetch when dependencies change
+    watch(
+        [
+            () => toValue(dataModelId),
+            () => toValue(campaignId),
+            () => toValue(startDate),
+            () => toValue(endDate),
+        ],
+        () => { fetch(); },
+        { immediate: true },
+    );
+
+    return {
+        data,
+        isLoading,
+        hasFetched,
+        error,
+        fetch,
+        formatCurrency,
+        formatNumber,
+        formatPercent,
+        formatRatio,
+    };
+}

--- a/frontend/pages/projects/[projectid]/intelligence/campaigns/[campaignid].vue
+++ b/frontend/pages/projects/[projectid]/intelligence/campaigns/[campaignid].vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+/**
+ * Campaign Drill-Down Page — CMP-001
+ *
+ * Route: /projects/:projectid/intelligence/campaigns/:campaignid
+ *
+ * Shows full campaign performance analysis when a user clicks a campaign
+ * from the Campaign Performance Table.
+ */
+import { useMarketingHubStore } from '@/stores/marketingHub';
+import { useDataModelsStore } from '@/stores/data_models';
+import CampaignDrillDown from '@/components/intelligence/campaign/CampaignDrillDown.vue';
+
+definePageMeta({ layout: 'project' });
+
+const route = useRoute();
+const router = useRouter();
+const marketingHubStore = useMarketingHubStore();
+const dataModelsStore = useDataModelsStore();
+
+const projectId = computed(() => parseInt(String(route.params.projectid)));
+const campaignId = computed(() => String(route.params.campaignid));
+
+/** First data model ID for the current project */
+const firstDataModelId = computed<number | null>(() => {
+    const models = dataModelsStore.getDataModels();
+    const projectModels = models.filter(
+        (m: any) => m.data_source?.project_id === projectId.value
+            || m.data_model_sources?.some((dms: any) => dms.data_source?.project_id === projectId.value),
+    );
+    return projectModels.length > 0 ? projectModels[0].id : null;
+});
+
+/** ISO date strings from the marketing hub store */
+const isoStartDate = computed(() => marketingHubStore.dateRange.start.toISOString().split('T')[0]);
+const isoEndDate = computed(() => marketingHubStore.dateRange.end.toISOString().split('T')[0]);
+
+/** Campaign metadata from URL query params (passed from table click) */
+const campaignName = computed(() => (route.query.name as string) || '');
+const channel = computed(() => (route.query.channel as string) || '');
+
+function handleBack() {
+    router.push(`/projects/${projectId.value}/intelligence#campaigns`);
+}
+
+onMounted(async () => {
+    await dataModelsStore.retrieveDataModels(projectId.value);
+});
+</script>
+
+<template>
+    <IntelligenceHubLayout>
+        <div class="flex-1 min-w-0 p-4 md:p-6 overflow-y-auto">
+            <CampaignDrillDown
+                :data-model-id="firstDataModelId"
+                :campaign-id="campaignId"
+                :campaign-name="campaignName"
+                :channel="channel"
+                :start-date="isoStartDate"
+                :end-date="isoEndDate"
+                @back="handleBack"
+            />
+        </div>
+    </IntelligenceHubLayout>
+</template>

--- a/frontend/pages/projects/[projectid]/intelligence/index.vue
+++ b/frontend/pages/projects/[projectid]/intelligence/index.vue
@@ -146,6 +146,16 @@ function handleRangeChange(range: { start: Date; end: Date; preset: string }) {
     loadOverviewData();
 }
 
+function navigateToCampaignDrillDown(campaign: any) {
+    const query: Record<string, string> = {};
+    if (campaign.campaignName) query.name = campaign.campaignName;
+    if (campaign.channel) query.channel = campaign.channel;
+    router.push({
+        path: `/projects/${projectId.value}/intelligence/campaigns/${campaign.campaignId}`,
+        query,
+    });
+}
+
 // Top campaigns helpers
 function platformIcon(platform: string): [string, string] {
     switch (platform) {
@@ -216,6 +226,7 @@ onMounted(async () => {
                     :end-date="isoEndDate"
                     @refresh="handleRefresh"
                     @update:range="handleRangeChange"
+                    @campaign-click="navigateToCampaignDrillDown"
                 />
             </div>
 
@@ -237,6 +248,7 @@ onMounted(async () => {
                     :channels="summary?.channels?.map((ch: any) => ch.channelLabel || ch.channelType || 'Unknown') || []"
                     :max-height="600"
                     :show-filters="true"
+                    @campaign-click="navigateToCampaignDrillDown"
                 />
                 <div v-else class="flex flex-col items-center justify-center py-20 text-center">
                     <font-awesome-icon :icon="['fas', 'bullhorn']" class="text-4xl text-gray-300 mb-4" />


### PR DESCRIPTION
## Description
feat(intelligence): add campaign drill-down page with KPI cards, trend chart, and dimension breakdown

- Add CampaignDrillDown component composing KPI cards, trend chart, and dimension breakdown tabs (ad group, keyword, device, geo)
- Add CampaignKPICards, CampaignTrendChart, and DimensionBreakdown components
- Add useCampaignDrillDown composable for fetching campaign-level data
- Add new route page at /projects/:projectid/intelligence/campaigns/:campaignid
- Wire campaign-click events from CampaignPerformanceTable through IntelligenceOverview and intelligence index page to navigate to drill-down
- Update campaign barrel exports in index.ts

## Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [ ] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce and validate the behavior.

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist

Please check all the boxes that apply:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [ ] I have linked the related issue(s) in the description.

## Screenshots (if applicable)

> Add screenshots to help explain your changes if visual updates are involved.

---