### PR TITLE
DRA-338-TICKET-AI-001-Modify-AI-Insights-Endpoint-to-Accept-Data-Model-IDs

### DIFF
--- a/backend/src/controllers/InsightsController.ts
+++ b/backend/src/controllers/InsightsController.ts
@@ -11,13 +11,38 @@ export class InsightsController {
      */
     static async initializeSession(req: Request, res: Response): Promise<void> {
         try {
-            const { projectId, dataSourceIds } = req.body;
+            const { projectId, dataSourceIds, dataModelIds } = req.body;
             const tokenDetails = req.body.tokenDetails;
             const userId = tokenDetails?.user_id;
 
-            if (!projectId || !dataSourceIds || !Array.isArray(dataSourceIds) || dataSourceIds.length === 0) {
+            const hasDataSources = Array.isArray(dataSourceIds) && dataSourceIds.length > 0;
+            const hasDataModels = Array.isArray(dataModelIds) && dataModelIds.length > 0;
+
+            if (!projectId) {
                 res.status(400).json({ 
-                    error: 'projectId and dataSourceIds (array with at least 1 element) are required' 
+                    error: 'projectId is required' 
+                });
+                return;
+            }
+
+            if (!hasDataSources && !hasDataModels) {
+                res.status(400).json({ 
+                    error: 'At least one of dataSourceIds or dataModelIds (array with at least 1 element) is required' 
+                });
+                return;
+            }
+
+            // Validate types if provided
+            if (dataSourceIds !== undefined && !Array.isArray(dataSourceIds)) {
+                res.status(400).json({ 
+                    error: 'dataSourceIds must be an array of numbers' 
+                });
+                return;
+            }
+
+            if (dataModelIds !== undefined && !Array.isArray(dataModelIds)) {
+                res.status(400).json({ 
+                    error: 'dataModelIds must be an array of numbers when provided' 
                 });
                 return;
             }
@@ -27,7 +52,8 @@ export class InsightsController {
                 projectId,
                 dataSourceIds,
                 userId,
-                tokenDetails
+                tokenDetails,
+                dataModelIds
             );
 
             if (result.success) {

--- a/backend/src/processors/InsightsProcessor.ts
+++ b/backend/src/processors/InsightsProcessor.ts
@@ -164,6 +164,49 @@ export class InsightsProcessor {
     }
 
     /**
+     * Validate that data model IDs belong to the project and are within the selected data sources.
+     * Also resolves their associated data source IDs so callers can use them.
+     */
+    private async validateDataModels(
+        projectId: number,
+        dataModelIds: number[],
+        dataSourceIds: number[]
+    ): Promise<{ valid: boolean; error?: string }> {
+        const driver = await DBDriver.getInstance().getDriver(EDataSourceType.POSTGRESQL);
+        const manager = (await driver.getConcreteDriver()).manager;
+
+        // Only validate against dataSourceIds if they were explicitly provided
+        const hasDataSourceConstraint = dataSourceIds.length > 0;
+        const dataSourceIdSet = new Set(dataSourceIds);
+
+        for (const dataModelId of dataModelIds) {
+            const dataModel = await manager.findOne(DRADataModel, {
+                where: { id: dataModelId },
+                relations: ['data_source']
+            });
+
+            if (!dataModel) {
+                return { valid: false, error: `Data model ${dataModelId} not found` };
+            }
+
+            // Ensure the data model belongs to this project (verify via data source ownership)
+            if (!dataModel.data_source) {
+                return { valid: false, error: `Data model ${dataModelId} has no associated data source` };
+            }
+
+            // If explicit dataSourceIds were provided, ensure the model is within that set
+            if (hasDataSourceConstraint && !dataSourceIdSet.has(dataModel.data_source.id)) {
+                return {
+                    valid: false,
+                    error: `Data model ${dataModelId} belongs to data source ${dataModel.data_source.id} which is not in the selected data sources`
+                };
+            }
+        }
+
+        return { valid: true };
+    }
+
+    /**
      * Generate suggested questions from insights
      * @param insights - The insights object returned by AI
      * @returns Markdown formatted list of suggested questions
@@ -229,7 +272,8 @@ export class InsightsProcessor {
         projectId: number,
         dataSourceIds: number[],
         userId: number,
-        tokenDetails: ITokenDetails
+        tokenDetails: ITokenDetails,
+        dataModelIds?: number[]
     ): Promise<InitializeSessionResponse> {
         try {
             // Validate project access
@@ -238,19 +282,63 @@ export class InsightsProcessor {
                 return {
                     success: false,
                     projectId,
-                    dataSourceIds,
+                    dataSourceIds: dataSourceIds || [],
                     error: projectValidation.error
                 };
             }
 
-            // Validate data sources
-            const dataSourceValidation = await this.validateDataSources(projectId, dataSourceIds);
-            if (!dataSourceValidation.valid) {
+            const driver = await DBDriver.getInstance().getDriver(EDataSourceType.POSTGRESQL);
+            const manager = (await driver.getConcreteDriver()).manager;
+
+            let resolvedDataSourceIds = dataSourceIds || [];
+            let resolvedDataModelIds: number[] | undefined = undefined;
+
+            if (dataModelIds && dataModelIds.length > 0) {
+                // If no dataSourceIds provided, resolve them from the data models first
+                if (resolvedDataSourceIds.length === 0) {
+                    const modelsForResolution = await manager.find(DRADataModel, {
+                        where: { id: In(dataModelIds) },
+                        relations: ['data_source']
+                    });
+                    const dsIdSet = new Set<number>();
+                    for (const dm of modelsForResolution) {
+                        if (dm.data_source?.id) {
+                            dsIdSet.add(dm.data_source.id);
+                        }
+                    }
+                    resolvedDataSourceIds = Array.from(dsIdSet);
+                }
+
+                // Validate data models belong to the project (and are within resolved dataSourceIds)
+                const dmValidation = await this.validateDataModels(projectId, dataModelIds, resolvedDataSourceIds);
+                if (!dmValidation.valid) {
+                    return {
+                        success: false,
+                        projectId,
+                        dataSourceIds: resolvedDataSourceIds,
+                        error: dmValidation.error
+                    };
+                }
+                resolvedDataModelIds = dataModelIds;
+            }
+
+            // Validate data sources (if any)
+            if (resolvedDataSourceIds.length > 0) {
+                const dataSourceValidation = await this.validateDataSources(projectId, resolvedDataSourceIds);
+                if (!dataSourceValidation.valid) {
+                    return {
+                        success: false,
+                        projectId,
+                        dataSourceIds: resolvedDataSourceIds,
+                        error: dataSourceValidation.error
+                    };
+                }
+            } else {
                 return {
                     success: false,
                     projectId,
-                    dataSourceIds,
-                    error: dataSourceValidation.error
+                    dataSourceIds: [],
+                    error: 'No data sources found for the provided data models'
                 };
             }
 
@@ -268,7 +356,7 @@ export class InsightsProcessor {
                 const draft = await this.redisSessionService.getInsightDraft(projectId, userId);
 
                 const storedIds: number[] = (draft?.dataSourceIds ?? []).slice().sort((a: number, b: number) => a - b);
-                const incomingIds: number[] = dataSourceIds.slice().sort((a, b) => a - b);
+                const incomingIds: number[] = resolvedDataSourceIds.slice().sort((a, b) => a - b);
                 const idsMatch =
                     storedIds.length === incomingIds.length &&
                     storedIds.every((id, i) => id === incomingIds[i]);
@@ -279,7 +367,7 @@ export class InsightsProcessor {
                         success: true,
                         conversationId: existingSession.conversationId,
                         projectId,
-                        dataSourceIds
+                        dataSourceIds: resolvedDataSourceIds
                     };
                 }
                 // Data sources changed — invalidate the old session and rebuild below
@@ -295,14 +383,24 @@ export class InsightsProcessor {
             });
 
             // Load data models for this project to get logical table names
-            const driver = await DBDriver.getInstance().getDriver(EDataSourceType.POSTGRESQL);
-            const manager = (await driver.getConcreteDriver()).manager;
-            const dataModels = await manager.find(DRADataModel, {
-                where: { 
-                    data_source: { id: In(dataSourceIds) }
-                },
-                select: ['schema', 'name', 'query']
-            });
+            // If specific data model IDs were provided, fetch only those; otherwise fetch all for the data sources
+            const dataModels = resolvedDataModelIds && resolvedDataModelIds.length > 0
+                ? await manager.find(DRADataModel, {
+                    where: {
+                        id: In(resolvedDataModelIds)
+                    },
+                    select: ['id', 'schema', 'name', 'query']
+                })
+                : await manager.find(DRADataModel, {
+                    where: { 
+                        data_source: { id: In(resolvedDataSourceIds) }
+                    },
+                    select: ['id', 'schema', 'name', 'query']
+                });
+
+            if (resolvedDataModelIds) {
+                console.log(`[InsightsProcessor] Scoped to ${dataModels.length} data model IDs: [${resolvedDataModelIds.join(', ')}]`);
+            }
 
             // Build mapping of physical table names to logical names
             // Format: "schema.tablename" -> "Logical Name"
@@ -317,7 +415,7 @@ export class InsightsProcessor {
 
             const { context, markdown } = await this.dataSamplingService.buildInsightContext(
                 projectId,
-                dataSourceIds,
+                resolvedDataSourceIds,
                 tokenDetails,
                 tableNameMapping
             );
@@ -344,7 +442,8 @@ export class InsightsProcessor {
             await this.redisSessionService.saveInsightSchemaMarkdown(projectId, userId, markdown);
             await this.redisSessionService.saveInsightSamplingInfo(projectId, userId, context.sampling_info ?? null);
             await this.redisSessionService.saveInsightDraft(projectId, userId, {
-                dataSourceIds,
+                dataSourceIds: resolvedDataSourceIds,
+                dataModelIds: resolvedDataModelIds || [],
                 insights: null,
                 selectedSources: context.data_sources.map((ds: any) => ds.data_source_name),
                 lastModified: new Date().toISOString(),
@@ -376,7 +475,7 @@ export class InsightsProcessor {
                 success: true,
                 conversationId: session.conversationId,
                 projectId,
-                dataSourceIds
+                dataSourceIds: resolvedDataSourceIds
             };
 
         } catch (error: any) {
@@ -384,7 +483,7 @@ export class InsightsProcessor {
             return {
                 success: false,
                 projectId,
-                dataSourceIds,
+                dataSourceIds: dataSourceIds || [],
                 error: error.message
             };
         }

--- a/backend/src/routes/insights.ts
+++ b/backend/src/routes/insights.ts
@@ -4,6 +4,7 @@ import { validate } from '../middleware/validator.js';
 import { body, param } from 'express-validator';
 import { InsightsController } from '../controllers/InsightsController.js';
 import { aiOperationsLimiter, insightsLimiter } from '../middleware/rateLimit.js';
+import { ValidationChain } from 'express-validator';
 
 const router = express.Router();
 
@@ -19,8 +20,18 @@ router.post(
     insightsLimiter,
     validate([
         body('projectId').notEmpty().isInt().withMessage('projectId must be a valid integer'),
-        body('dataSourceIds').isArray({ min: 1 }).withMessage('dataSourceIds must be a non-empty array'),
-        body('dataSourceIds.*').isInt().withMessage('Each dataSourceId must be an integer')
+        body('dataSourceIds').optional().isArray().withMessage('dataSourceIds must be an array'),
+        body('dataSourceIds.*').isInt().withMessage('Each dataSourceId must be an integer'),
+        body('dataModelIds').optional().isArray().withMessage('dataModelIds must be an array'),
+        body('dataModelIds.*').isInt().withMessage('Each dataModelId must be an integer'),
+        body().custom((value) => {
+            const hasDataSources = Array.isArray(value.dataSourceIds) && value.dataSourceIds.length > 0;
+            const hasDataModels = Array.isArray(value.dataModelIds) && value.dataModelIds.length > 0;
+            if (!hasDataSources && !hasDataModels) {
+                throw new Error('At least one of dataSourceIds or dataModelIds must be provided');
+            }
+            return true;
+        })
     ]),
     async (req: Request, res: Response) => {
         await InsightsController.initializeSession(req, res);

--- a/frontend/stores/insights.ts
+++ b/frontend/stores/insights.ts
@@ -207,7 +207,7 @@ export const useInsightsStore = defineStore('insights', () => {
     /**
      * Initialize insights session
      */
-    async function initializeSession(projectId: number, dataSourceIds: number[]) {
+    async function initializeSession(projectId: number, dataSourceIds: number[], dataModelIds?: number[]) {
         try {
             error.value = null;
             isGenerating.value = true;
@@ -227,7 +227,8 @@ export const useInsightsStore = defineStore('insights', () => {
                 },
                 body: {
                     projectId,
-                    dataSourceIds
+                    dataSourceIds,
+                    ...(dataModelIds && dataModelIds.length > 0 ? { dataModelIds } : {})
                 }
             });
 


### PR DESCRIPTION
## Description

feat(AI-001): add dataModelIds support to AI Insights endpoint
Allow the insights session initialization endpoint to accept data model IDs as an alternative to (or alongside) data source IDs.

Backend:
- InsightsProcessor: add validateDataModels() method, auto-resolve dataSourceIds from dataModelIds when only models are provided, scope data model queries to resolved IDs, and persist dataModelIds in the Redis draft.
- InsightsController: extract and validate dataModelIds from request body; require at least one of dataSourceIds or dataModelIds.
- Routes/insights: make dataSourceIds optional, add dataModelIds validation chain with custom body-level "at least one" guard.

Frontend:
- insights store: accept optional dataModelIds in initializeSession() and include them in the POST body when present.

## Type of Change

Please delete options that are not relevant:

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [ ] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce and validate the behavior.

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Checklist

Please check all the boxes that apply:

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [ ] I have linked the related issue(s) in the description.

---