### PR TITLE
DRA-349-Implement-Branding-Functionality

### DIFF
--- a/backend/src/migrations/1788000000001-AddOrganizationBranding.ts
+++ b/backend/src/migrations/1788000000001-AddOrganizationBranding.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrganizationBranding1788000000001 implements MigrationInterface {
+    name = 'AddOrganizationBranding1788000000001';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "dra_organizations"
+            ADD COLUMN "primary_color" VARCHAR(7) DEFAULT NULL
+        `);
+
+        await queryRunner.query(`
+            ALTER TABLE "dra_organizations"
+            ADD COLUMN "secondary_color" VARCHAR(7) DEFAULT NULL
+        `);
+
+        await queryRunner.query(`
+            ALTER TABLE "dra_organizations"
+            ADD COLUMN "branding_enabled" BOOLEAN NOT NULL DEFAULT false
+        `);
+
+        await queryRunner.query(`
+            ALTER TABLE "dra_organizations"
+            ADD COLUMN "branding_logo_url" TEXT DEFAULT NULL
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "dra_organizations" DROP COLUMN "branding_logo_url"`);
+        await queryRunner.query(`ALTER TABLE "dra_organizations" DROP COLUMN "branding_enabled"`);
+        await queryRunner.query(`ALTER TABLE "dra_organizations" DROP COLUMN "secondary_color"`);
+        await queryRunner.query(`ALTER TABLE "dra_organizations" DROP COLUMN "primary_color"`);
+    }
+}

--- a/backend/src/models/DRAOrganization.ts
+++ b/backend/src/models/DRAOrganization.ts
@@ -45,6 +45,18 @@ export class DRAOrganization {
     @Column({ type: 'boolean', default: false })
     sso_enabled!: boolean;
 
+    @Column({ type: 'varchar', length: 7, nullable: true })
+    primary_color!: string | null;
+
+    @Column({ type: 'varchar', length: 7, nullable: true })
+    secondary_color!: string | null;
+
+    @Column({ type: 'boolean', default: false })
+    branding_enabled!: boolean;
+
+    @Column({ type: 'text', nullable: true })
+    branding_logo_url!: string | null;
+
     @Column({ type: 'jsonb', default: {} })
     settings!: Record<string, any>;  // Org-wide preferences, branding, API keys
 

--- a/backend/src/processors/AuthProcessor.ts
+++ b/backend/src/processors/AuthProcessor.ts
@@ -231,7 +231,7 @@ export class AuthProcessor {
                         console.log(`📨 User ${newUser.id} (${email}) has ${pendingInvitations.length} pending invitation(s) - skipping personal organization creation`);
                     } else {
                         const orgName = `${firstName}'s Organization`;
-                        const freeTier = await manager.findOne(DRASubscriptionTier, { where: { tier_name: 'free' } });
+                        const freeTier = await manager.findOne(DRASubscriptionTier, { where: { tier_name: 'Free' } });
                         
                         if (freeTier) {
                             const personalOrg = await this.organizationService.createOrganization({

--- a/backend/src/processors/EmailFunnelProcessor.ts
+++ b/backend/src/processors/EmailFunnelProcessor.ts
@@ -221,6 +221,25 @@ export class EmailFunnelProcessor {
         for (const enrollment of readyEnrollments) {
             if (!this.checkDailyLimit()) break;
 
+            const isUnsub = await this.isUnsubscribed(enrollment.lead_email, enrollment.funnel_id);
+            if (isUnsub) {
+                enrollment.is_active = false;
+                await manager.save(enrollment);
+                continue;
+            }
+
+            if (enrollment.user_id) {
+                const user = await manager.findOne(DRAUsersPlatform, {
+                    where: { id: enrollment.user_id },
+                    select: ['unsubscribe_from_emails_at'],
+                });
+                if (user?.unsubscribe_from_emails_at) {
+                    enrollment.is_active = false;
+                    await manager.save(enrollment);
+                    continue;
+                }
+            }
+
             const steps = await manager.find(DRAEmailFunnelStep, {
                 where: { funnel_id: enrollment.funnel_id, is_active: true },
                 order: { step_order: 'ASC' },
@@ -538,8 +557,15 @@ export class EmailFunnelProcessor {
         const textBody = articles.map(a => `- ${a.title}: ${frontendUrl}/articles/${a.slug}`).join('\n');
 
         let sent = 0;
+        let skipped = 0;
         for (const recipient of recipients) {
             if (!this.checkDailyLimit()) break;
+
+            const isUnsub = await this.isUnsubscribed(recipient.email, blogFunnel?.id || 0);
+            if (isUnsub) {
+                skipped++;
+                continue;
+            }
 
             const firstName = recipient.name?.split(' ')[0] || 'there';
             const unsubscribeToken = this.generateUnsubscribeToken(recipient.email, blogFunnel?.id || 0);
@@ -574,7 +600,7 @@ export class EmailFunnelProcessor {
         digest.sent_count = sent;
         await manager.save(digest);
 
-        return { sent, skipped: 0, digestId: digest.id };
+        return { sent, skipped, digestId: digest.id };
     }
 
     async renderBlogDigestPreview(articleIds: number[]): Promise<string | null> {
@@ -756,6 +782,12 @@ export class EmailFunnelProcessor {
             for (let i = broadcast.sent_count; i < subscribers.length; i++) {
                 if (!this.checkDailyLimit()) break;
                 const sub = subscribers[i];
+
+                const isUnsub = await this.isUnsubscribed(sub.email, blogFunnel?.id || 0);
+                if (isUnsub) {
+                    broadcast.sent_count += 1;
+                    continue;
+                }
 
                 const firstName = sub.name?.split(' ')[0] || 'there';
                 const unsubscribeToken = this.generateUnsubscribeToken(sub.email, blogFunnel?.id || 0);

--- a/backend/src/processors/SubscriptionProcessor.ts
+++ b/backend/src/processors/SubscriptionProcessor.ts
@@ -12,6 +12,7 @@ import { PaymentAlertService } from '../services/PaymentAlertService.js';
 import { PaddleService } from '../services/PaddleService.js';
 import { EmailService } from '../services/EmailService.js';
 import { TemplateEngineService } from '../services/TemplateEngineService.js';
+import { EmailPreferencesProcessor } from '../processors/EmailPreferencesProcessor.js';
 import { In } from 'typeorm';
 
 /**
@@ -309,17 +310,25 @@ export class SubscriptionProcessor {
                 aiGenerationsPerMonth: tier.ai_generations_per_month === null || tier.ai_generations_per_month === -1 ? 'Unlimited' : tier.ai_generations_per_month.toString(),
                 maxRowsPerDataModel: tier.max_rows_per_data_model === null || tier.max_rows_per_data_model === -1 ? 'Unlimited' : tier.max_rows_per_data_model.toString()
             };
-            
+
             const nextPaymentDate = subscription.ends_at || new Date();
-            
-            await EmailService.getInstance().sendSubscriptionActivated(
-                ownerEmail,
-                ownerName,
-                tier.tier_name.toUpperCase(),
-                tierDetails,
-                paddleData.billing_cycle === 'monthly' ? 'Monthly' : 'Annual',
-                nextPaymentDate
-            );
+
+            const ownerMember = await manager.findOne(DRAOrganizationMember, {
+                where: { organization_id: organizationId, role: 'owner', is_active: true },
+            });
+            const canSend = ownerMember
+                ? await EmailPreferencesProcessor.getInstance().canSendEmail(ownerMember.users_platform_id, 'subscription_updates')
+                : true;
+            if (canSend) {
+                await EmailService.getInstance().sendSubscriptionActivated(
+                    ownerEmail,
+                    ownerName,
+                    tier.tier_name.toUpperCase(),
+                    tierDetails,
+                    paddleData.billing_cycle === 'monthly' ? 'Monthly' : 'Annual',
+                    nextPaymentDate
+                );
+            }
         }
         
         console.log(`✅ Subscription activated for organization ${organizationId} (tier: ${tier.tier_name})`);
@@ -428,21 +437,28 @@ export class SubscriptionProcessor {
         const ownerName = organization.settings?.owner_name || organization.name;
         
         if (ownerEmail) {
-            // Get unlocked features (simplified - shows tier names)
             const newFeatures = [
                 `Upgraded to ${newTier.tier_name.toUpperCase()}`,
                 `${newTier.max_projects === null ? 'Unlimited' : newTier.max_projects} projects`,
                 `${newTier.max_data_sources_per_project === null ? 'Unlimited' : newTier.max_data_sources_per_project} data sources per project`,
                 `${newTier.max_dashboards === null ? 'Unlimited' : newTier.max_dashboards} dashboards`
             ];
-            
-            await EmailService.getInstance().sendSubscriptionUpgraded(
-                ownerEmail,
-                ownerName,
-                currentTier.tier_name.toUpperCase(),
-                newTier.tier_name.toUpperCase(),
-                newFeatures
-            );
+
+            const ownerMember = await manager.findOne(DRAOrganizationMember, {
+                where: { organization_id: organizationId, role: 'owner', is_active: true },
+            });
+            const canSend = ownerMember
+                ? await EmailPreferencesProcessor.getInstance().canSendEmail(ownerMember.users_platform_id, 'subscription_updates')
+                : true;
+            if (canSend) {
+                await EmailService.getInstance().sendSubscriptionUpgraded(
+                    ownerEmail,
+                    ownerName,
+                    currentTier.tier_name.toUpperCase(),
+                    newTier.tier_name.toUpperCase(),
+                    newFeatures
+                );
+            }
         }
         
         console.log(`✅ Subscription upgraded: ${currentTier.tier_name} → ${newTier.tier_name} for org ${organizationId}`);
@@ -525,16 +541,24 @@ export class SubscriptionProcessor {
             const currentTierForEmail = await manager.findOne(DRASubscriptionTier, {
                 where: { id: organization.subscription!.subscription_tier_id }
             });
-            
+
             const effectiveDate = organization.subscription!.ends_at || new Date();
-            
-            await EmailService.getInstance().sendSubscriptionDowngraded(
-                ownerEmail,
-                ownerName,
-                currentTierForEmail?.tier_name.toUpperCase() || 'UNKNOWN',
-                newTier.tier_name.toUpperCase(),
-                effectiveDate
-            );
+
+            const ownerMember = await manager.findOne(DRAOrganizationMember, {
+                where: { organization_id: organizationId, role: 'owner', is_active: true },
+            });
+            const canSend = ownerMember
+                ? await EmailPreferencesProcessor.getInstance().canSendEmail(ownerMember.users_platform_id, 'subscription_updates')
+                : true;
+            if (canSend) {
+                await EmailService.getInstance().sendSubscriptionDowngraded(
+                    ownerEmail,
+                    ownerName,
+                    currentTierForEmail?.tier_name.toUpperCase() || 'UNKNOWN',
+                    newTier.tier_name.toUpperCase(),
+                    effectiveDate
+                );
+            }
         }
         
         console.log(`✅ Subscription downgraded to ${newTier.tier_name} for org ${organizationId}`);
@@ -586,15 +610,23 @@ export class SubscriptionProcessor {
             const tier = await manager.findOne(DRASubscriptionTier, {
                 where: { id: organization.subscription.subscription_tier_id }
             });
-            
+
             const effectiveDate = organization.subscription.ends_at || new Date();
-            
-            await EmailService.getInstance().sendSubscriptionCancelled(
-                ownerEmail,
-                ownerName,
-                tier?.tier_name.toUpperCase() || 'UNKNOWN',
-                effectiveDate
-            );
+
+            const ownerMember = await manager.findOne(DRAOrganizationMember, {
+                where: { organization_id: organizationId, role: 'owner', is_active: true },
+            });
+            const canSend = ownerMember
+                ? await EmailPreferencesProcessor.getInstance().canSendEmail(ownerMember.users_platform_id, 'subscription_updates')
+                : true;
+            if (canSend) {
+                await EmailService.getInstance().sendSubscriptionCancelled(
+                    ownerEmail,
+                    ownerName,
+                    tier?.tier_name.toUpperCase() || 'UNKNOWN',
+                    effectiveDate
+                );
+            }
         }
         
         return organization.subscription;
@@ -1492,21 +1524,21 @@ export class SubscriptionProcessor {
                 const oldTier = await manager.findOne(DRASubscriptionTier, {
                     where: { id: subscription.subscription_tier_id }
                 });
-                
+
                 const oldTierDetails = {
                     maxProjects: oldTier?.max_projects?.toString() || 'Unlimited',
                     maxDataSources: oldTier?.max_data_sources_per_project?.toString() || 'Unlimited',
                     maxDashboards: oldTier?.max_dashboards?.toString() || 'Unlimited',
                     aiGenerationsPerMonth: oldTier?.ai_generations_per_month?.toString() || 'Unlimited'
                 };
-                
+
                 const newTierDetails = {
                     maxProjects: freeTier.max_projects?.toString() || '1',
                     maxDataSources: freeTier.max_data_sources_per_project?.toString() || '2',
                     maxDashboards: freeTier.max_dashboards?.toString() || '2',
                     aiGenerationsPerMonth: freeTier.ai_generations_per_month?.toString() || '5'
                 };
-                
+
                 await EmailService.getInstance().sendDowngradedToFree(
                     ownerEmail,
                     ownerName,
@@ -1587,14 +1619,14 @@ export class SubscriptionProcessor {
                     maxDashboards: subscription.subscription_tier?.max_dashboards?.toString() || 'Unlimited',
                     aiGenerationsPerMonth: subscription.subscription_tier?.ai_generations_per_month?.toString() || 'Unlimited'
                 };
-                
+
                 const newTierDetails = {
                     maxProjects: freeTier.max_projects?.toString() || '1',
                     maxDataSources: freeTier.max_data_sources_per_project?.toString() || '2',
                     maxDashboards: freeTier.max_dashboards?.toString() || '2',
                     aiGenerationsPerMonth: freeTier.ai_generations_per_month?.toString() || '5'
                 };
-                
+
                 try {
                     await EmailService.getInstance().sendDowngradedToFree(
                         ownerEmail,

--- a/backend/src/processors/SubscriptionProcessor.ts
+++ b/backend/src/processors/SubscriptionProcessor.ts
@@ -138,9 +138,9 @@ export class SubscriptionProcessor {
             
             // Save customer ID to local database
             if (!organization.subscription) {
-                const freeTier = await manager.findOneOrFail(DRASubscriptionTier, {
-                    where: { tier_name: 'free' }
-                });
+            const freeTier = await manager.findOneOrFail(DRASubscriptionTier, {
+                where: { tier_name: 'Free' }
+            });
                 
                 const newSubscription = manager.create(DRAOrganizationSubscription, {
                     organization_id: organizationId,
@@ -483,7 +483,7 @@ export class SubscriptionProcessor {
         });
         
         // If downgrading to FREE, cancel Paddle subscription
-        if (newTier.tier_name === 'free') {
+        if (newTier.tier_name === 'Free') {
             if (organization.subscription?.paddle_subscription_id) {
                 const paddle = PaddleService.getInstance();
                 await paddle.cancelSubscription(
@@ -631,7 +631,22 @@ export class SubscriptionProcessor {
         });
         
         if (!organization.subscription) {
-            throw new Error('Organization has no active subscription');
+            const freeTier = await manager.findOneOrFail(DRASubscriptionTier, {
+                where: { tier_name: 'Free' }
+            });
+
+            const newSubscription = manager.create(DRAOrganizationSubscription, {
+                organization_id: organizationId,
+                subscription_tier_id: freeTier.id,
+                billing_cycle: billingCycle || 'monthly',
+                is_active: true
+            });
+
+            await manager.save(newSubscription);
+            organization.subscription = newSubscription;
+            organization.subscription.subscription_tier = freeTier;
+
+            console.log(`[changeTier] Auto-created subscription for organization ${organizationId}`);
         }
         
         // Load new tier
@@ -719,7 +734,7 @@ export class SubscriptionProcessor {
         }
         
         // Special handling for downgrade to Free tier
-        if (newTier.tier_name === 'free') {
+        if (newTier.tier_name === 'Free') {
             // Cancel Paddle subscription if it exists
             if (hasPaddleSubscription && organization.subscription.paddle_subscription_id) {
                 console.log(`🔄 Cancelling Paddle subscription for Org ${organizationId} (downgrade to Free)`);
@@ -789,7 +804,7 @@ export class SubscriptionProcessor {
         }
         
         // Now update Paddle subscription (after database is updated)
-        if (newTier.tier_name !== 'free' && hasPaddleSubscription && organization.subscription.paddle_subscription_id) {
+        if (newTier.tier_name !== 'Free' && hasPaddleSubscription && organization.subscription.paddle_subscription_id) {
             // Route A: Update via Paddle API with automatic proration (paid tier to paid tier)
             console.log(`🔄 Updating Paddle subscription for Org ${organizationId}`);
             
@@ -1012,7 +1027,7 @@ export class SubscriptionProcessor {
         let billingType: 'paddle' | 'manual' | 'free';
         if (hasPaddleSubscription) {
             billingType = 'paddle';
-        } else if (currentTier?.tier_name === 'free') {
+        } else if (currentTier?.tier_name === 'Free') {
             billingType = 'free';
         } else {
             billingType = 'manual';
@@ -1285,7 +1300,7 @@ export class SubscriptionProcessor {
         } else {
             // No paddle_subscription_id - check if they're on a paid tier
             const currentTierName = organization.subscription?.subscription_tier?.tier_name;
-            if (currentTierName && currentTierName !== 'free') {
+            if (currentTierName && currentTierName !== 'Free') {
                 console.log(`[validatePaymentMethod] Organization on paid tier "${currentTierName}" but no Paddle subscription ID`);
                 return { isValid: false, reason: 'No active subscription' };
             }
@@ -1460,7 +1475,7 @@ export class SubscriptionProcessor {
         for (const subscription of expiredSubscriptions) {
             // Downgrade to FREE tier
             const freeTier = await manager.findOneOrFail(DRASubscriptionTier, {
-                where: { tier_name: 'free' }
+                where: { tier_name: 'Free' }
             });
             
             subscription.subscription_tier_id = freeTier.id;

--- a/backend/src/routes/admin/image.ts
+++ b/backend/src/routes/admin/image.ts
@@ -33,7 +33,7 @@ router.post('/upload', async (req: Request, res: Response, next: any) => {
         return res.status(400).json({ message: 'No files uploaded.' });
     }
     const publicUrl = UtilityService.getInstance().getConstants('PUBLIC_BACKEND_URL');
-    const fileUrls = files//?.map(file => `${publicUrl}/uploads/${file.filename}`);
+    const fileUrls = (files as Express.Multer.File[]).map(file => ({ url: `${publicUrl}/uploads/${file.filename}`, path: file.path }));
     res.status(200).json({ urls: fileUrls });
 
 });

--- a/backend/src/routes/admin/subscription_tiers.ts
+++ b/backend/src/routes/admin/subscription_tiers.ts
@@ -168,7 +168,19 @@ router.put('/:id', async (req: Request, res: Response, next: any) => {
     body('is_active')
         .optional()
         .isBoolean()
-        .withMessage('is_active must be a boolean')
+        .withMessage('is_active must be a boolean'),
+    body('paddle_product_id')
+        .optional({ nullable: true })
+        .isString()
+        .withMessage('paddle_product_id must be a string'),
+    body('paddle_price_id_monthly')
+        .optional({ nullable: true })
+        .isString()
+        .withMessage('paddle_price_id_monthly must be a string'),
+    body('paddle_price_id_annual')
+        .optional({ nullable: true })
+        .isString()
+        .withMessage('paddle_price_id_annual must be a string')
 ]), async (req: Request, res: Response) => {
     try {
         const { id } = matchedData(req);

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -18,6 +18,7 @@ import { EAction } from '../services/PermissionService.js';
 import { aiOperationsLimiter } from '../middleware/rateLimit.js';
 import { optionalOrganizationContext, organizationContext, type IOrganizationContextRequest } from '../middleware/organizationContext.js';
 import { workspaceContext, type IWorkspaceContextRequest } from '../middleware/workspaceContext.js';
+import { BrandingService } from '../services/BrandingService.js';
 const router = express.Router();
 
 router.get('/list', async (req: Request, res: Response, next: any) => {
@@ -118,7 +119,12 @@ async (req: Request, res: Response) => {
     const { dashboard_key } = matchedData(req);
     const dashboard = await DashboardProcessor.getInstance().getPublicDashboard(encodeURIComponent(dashboard_key));
     if (dashboard) {
-        res.status(200).send(dashboard);
+        const brandingService = BrandingService.getInstance();
+        const projectId = (dashboard as any)?.dashboard?.project?.id;
+        const branding = projectId
+            ? await brandingService.getBrandingForProject(projectId)
+            : null;
+        res.status(200).send({ ...dashboard, branding });
     } else {
         res.status(400).send({message: 'The public dashboard link could not be retrieved.'});
     }

--- a/backend/src/routes/organizations.ts
+++ b/backend/src/routes/organizations.ts
@@ -5,6 +5,7 @@ import { body, param, query, matchedData } from 'express-validator';
 import { OrganizationProcessor } from '../processors/OrganizationProcessor.js';
 import { EOrganizationRole } from '../services/OrganizationService.js';
 import { organizationContext, requireOrganizationRole } from '../middleware/organizationContext.js';
+import { BrandingService } from '../services/BrandingService.js';
 
 const router = express.Router();
 const processor = OrganizationProcessor.getInstance();
@@ -490,6 +491,97 @@ router.post(
             ];
             const isUserError = userFacingErrors.some(msg => error.message?.includes(msg));
             res.status(isUserError ? 400 : 500).json({ success: false, error: error.message });
+        }
+    }
+);
+
+/**
+ * GET /organizations/:id/branding
+ * Get organization branding configuration.
+ * Public endpoint - used by public report/dashboard pages.
+ * Returns null if branding is not enabled or org is not eligible.
+ */
+router.get(
+    '/:id/branding',
+    validate([param('id').notEmpty().isInt().withMessage('Organization ID must be an integer')]),
+    async (req: Request, res: Response) => {
+        try {
+            const brandingService = BrandingService.getInstance();
+            const branding = await brandingService.getBranding(parseInt(req.params.id));
+
+            res.status(200).json({
+                success: true,
+                data: branding,
+            });
+        } catch (error: any) {
+            res.status(500).json({
+                success: false,
+                error: error.message,
+            });
+        }
+    }
+);
+
+/**
+ * PUT /organizations/:id/branding
+ * Update organization branding settings.
+ * Requires ADMIN or OWNER role. Org must have Professional Plus+ tier.
+ *
+ * Body:
+ * - primaryColor: string | null (hex color e.g. #3C8DBC)
+ * - secondaryColor: string | null (hex color e.g. #1E3050)
+ * - brandingEnabled: boolean
+ * - logoUrl: string | null
+ */
+router.put(
+    '/:id/branding',
+    validateJWT,
+    organizationContext,
+    requireOrganizationRole(EOrganizationRole.ADMIN),
+    validate([
+        param('id').notEmpty().isInt(),
+        body('primaryColor')
+            .optional({ values: 'null' })
+            .matches(/^#[0-9A-Fa-f]{6}$/)
+            .withMessage('primaryColor must be a hex color (e.g., #3C8DBC)'),
+        body('secondaryColor')
+            .optional({ values: 'null' })
+            .matches(/^#[0-9A-Fa-f]{6}$/)
+            .withMessage('secondaryColor must be a hex color (e.g., #1E3050)'),
+        body('brandingEnabled').optional().isBoolean().withMessage('brandingEnabled must be a boolean'),
+        body('logoUrl').optional({ values: 'null' }).isURL().withMessage('logoUrl must be a valid URL'),
+    ]),
+    async (req: Request, res: Response) => {
+        try {
+            const orgId = parseInt(req.params.id);
+            const brandingService = BrandingService.getInstance();
+
+            const eligible = await brandingService.orgEligibleForBranding(orgId);
+            if (!eligible) {
+                return res.status(402).json({
+                    success: false,
+                    message: 'Custom branding requires Professional Plus or Enterprise plan. Please upgrade to access this feature.',
+                });
+            }
+
+            const updateData: Record<string, any> = {};
+            if (req.body.primaryColor !== undefined) updateData.primaryColor = req.body.primaryColor || null;
+            if (req.body.secondaryColor !== undefined) updateData.secondaryColor = req.body.secondaryColor || null;
+            if (req.body.brandingEnabled !== undefined) updateData.brandingEnabled = Boolean(req.body.brandingEnabled);
+            if (req.body.logoUrl !== undefined) updateData.logoUrl = req.body.logoUrl || null;
+
+            const branding = await brandingService.updateBranding(orgId, updateData);
+
+            res.status(200).json({
+                success: true,
+                message: 'Branding updated successfully',
+                data: branding,
+            });
+        } catch (error: any) {
+            res.status(500).json({
+                success: false,
+                error: error.message,
+            });
         }
     }
 );

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -3,6 +3,7 @@ import { validateJWT } from '../middleware/authenticate.js';
 import { requiresProjectRole } from '../middleware/requiresProjectRole.js';
 import { ReportProcessor } from '../processors/ReportProcessor.js';
 import { ReportItemsService } from '../services/ReportItemsService.js';
+import { BrandingService } from '../services/BrandingService.js';
 
 const router = Router();
 const processor = ReportProcessor.getInstance();
@@ -39,7 +40,11 @@ router.get('/public/:key', validateJWT, async (req: Request, res: Response) => {
         if (!report) {
             return res.status(404).json({ success: false, error: 'Report not found or link has expired.' });
         }
-        res.json({ success: true, report });
+        const brandingService = BrandingService.getInstance();
+        const branding = report.project_id
+            ? await brandingService.getBrandingForProject(report.project_id)
+            : null;
+        res.json({ success: true, report, branding });
     } catch (error: any) {
         res.status(500).json({ success: false, error: error.message });
     }

--- a/backend/src/routes/subscription.ts
+++ b/backend/src/routes/subscription.ts
@@ -583,6 +583,7 @@ router.get('/:organizationId', validateJWT, async (req: Request, res: Response) 
         const responseData = subscription ? {
             id: subscription.id,
             tier_name: subscription.subscription_tier?.tier_name || 'FREE',
+            tier_rank: subscription.subscription_tier?.tier_rank ?? 0,
             billing_cycle: subscription.billing_cycle,
             is_active: subscription.is_active,
             started_at: subscription.started_at,

--- a/backend/src/services/BrandingService.ts
+++ b/backend/src/services/BrandingService.ts
@@ -1,0 +1,224 @@
+import { DBDriver } from '../drivers/DBDriver.js';
+import { EDataSourceType } from '../types/EDataSourceType.js';
+import { DRAOrganization } from '../models/DRAOrganization.js';
+import { DRASubscriptionTier } from '../models/DRASubscriptionTier.js';
+import { DRAOrganizationSubscription } from '../models/DRAOrganizationSubscription.js';
+import { getRedisClient } from '../config/redis.config.js';
+
+export interface IBrandingConfig {
+    primaryColor: string | null;
+    secondaryColor: string | null;
+    logoUrl: string | null;
+    enabled: boolean;
+}
+
+const BRANDING_CACHE_TTL = 300; // 5 minutes
+const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/;
+const IMAGE_URL_EXTENSIONS = /\.(png|jpg|jpeg|gif|svg|webp|ico)($|\?)/i;
+
+export class BrandingService {
+    private static instance: BrandingService;
+    private redis = getRedisClient();
+
+    private constructor() {}
+
+    public static getInstance(): BrandingService {
+        if (!BrandingService.instance) {
+            BrandingService.instance = new BrandingService();
+        }
+        return BrandingService.instance;
+    }
+
+    private getCacheKey(orgId: number): string {
+        return `branding:org:${orgId}`;
+    }
+
+    /**
+     * Validate a hex color string
+     */
+    validateHexColor(color: string): boolean {
+        return HEX_COLOR_REGEX.test(color);
+    }
+
+    /**
+     * Check if the given org has an active subscription at Professional Plus tier or above (tier_rank >= 30).
+     */
+    async orgEligibleForBranding(orgId: number): Promise<boolean> {
+        const driver = await DBDriver.getInstance().getDriver(EDataSourceType.POSTGRESQL);
+        if (!driver) return false;
+
+        const concreteDriver = await driver.getConcreteDriver();
+        if (!concreteDriver?.manager) return false;
+
+        const sub = await concreteDriver.manager.findOne(DRAOrganizationSubscription, {
+            where: { organization: { id: orgId }, is_active: true },
+            relations: ['subscription_tier'],
+        });
+
+        if (!sub || !sub.subscription_tier) return false;
+
+        return sub.subscription_tier.tier_rank >= 30;
+    }
+
+    /**
+     * Get branding config for an org. Cached in Redis for 5 minutes.
+     * Returns null if branding is not enabled or org is not eligible.
+     */
+    async getBranding(orgId: number): Promise<IBrandingConfig | null> {
+        const cacheKey = this.getCacheKey(orgId);
+
+        try {
+            const cached = await this.redis.get(cacheKey);
+            if (cached) {
+                const parsed = JSON.parse(cached);
+                if (parsed === null) return null; // cached ineligible result
+                return parsed as IBrandingConfig;
+            }
+        } catch (err) {
+            console.warn('[BrandingService] Redis read failed:', err);
+        }
+
+        const driver = await DBDriver.getInstance().getDriver(EDataSourceType.POSTGRESQL);
+        if (!driver) return null;
+
+        const concreteDriver = await driver.getConcreteDriver();
+        if (!concreteDriver?.manager) return null;
+
+        const org = await concreteDriver.manager.findOne(DRAOrganization, {
+            where: { id: orgId },
+        });
+
+        if (!org) {
+            await this.setCache(cacheKey, null);
+            return null;
+        }
+
+        if (!org.branding_enabled) {
+            const eligible = await this.orgEligibleForBranding(orgId);
+            if (!eligible) {
+                await this.setCache(cacheKey, null);
+                return null;
+            }
+            // branding_enabled is false even though eligible; return disabled config
+            const config: IBrandingConfig = {
+                primaryColor: org.primary_color,
+                secondaryColor: org.secondary_color,
+                logoUrl: org.branding_logo_url,
+                enabled: false,
+            };
+            await this.setCache(cacheKey, config);
+            return config;
+        }
+
+        const config: IBrandingConfig = {
+            primaryColor: org.primary_color,
+            secondaryColor: org.secondary_color,
+            logoUrl: org.branding_logo_url,
+            enabled: true,
+        };
+
+        await this.setCache(cacheKey, config);
+        return config;
+    }
+
+    /**
+     * Get branding config for a project's org. Used by public dashboard/report endpoints.
+     */
+    async getBrandingForProject(projectId: number): Promise<IBrandingConfig | null> {
+        const driver = await DBDriver.getInstance().getDriver(EDataSourceType.POSTGRESQL);
+        if (!driver) return null;
+
+        const concreteDriver = await driver.getConcreteDriver();
+        if (!concreteDriver?.manager) return null;
+
+        const result = await concreteDriver.manager.query(
+            `SELECT p.organization_id FROM dra_projects p WHERE p.id = $1`,
+            [projectId]
+        );
+
+        if (!result || result.length === 0) return null;
+
+        return this.getBranding(result[0].organization_id);
+    }
+
+    /**
+     * Update branding settings for an organization.
+     * Only admins/owners should call this (enforced at route level).
+     */
+    async updateBranding(
+        orgId: number,
+        data: {
+            primaryColor?: string | null;
+            secondaryColor?: string | null;
+            brandingEnabled?: boolean;
+            logoUrl?: string | null;
+        }
+    ): Promise<IBrandingConfig> {
+        const driver = await DBDriver.getInstance().getDriver(EDataSourceType.POSTGRESQL);
+        if (!driver) throw new Error('Database driver not available');
+
+        const concreteDriver = await driver.getConcreteDriver();
+        if (!concreteDriver?.manager) throw new Error('Database manager not available');
+
+        const org = await concreteDriver.manager.findOne(DRAOrganization, { where: { id: orgId } });
+        if (!org) throw new Error('Organization not found');
+
+        if (data.primaryColor !== undefined) {
+            if (data.primaryColor !== null && !this.validateHexColor(data.primaryColor)) {
+                throw new Error('Invalid primary color format. Must be a hex color (e.g., #3C8DBC)');
+            }
+            org.primary_color = data.primaryColor;
+        }
+
+        if (data.secondaryColor !== undefined) {
+            if (data.secondaryColor !== null && !this.validateHexColor(data.secondaryColor)) {
+                throw new Error('Invalid secondary color format. Must be a hex color (e.g., #1E3050)');
+            }
+            org.secondary_color = data.secondaryColor;
+        }
+
+        if (data.logoUrl !== undefined) {
+            org.branding_logo_url = data.logoUrl;
+        }
+
+        if (data.brandingEnabled !== undefined) {
+            org.branding_enabled = data.brandingEnabled;
+        }
+
+        await concreteDriver.manager.save(org);
+
+        const config: IBrandingConfig = {
+            primaryColor: org.primary_color,
+            secondaryColor: org.secondary_color,
+            logoUrl: org.branding_logo_url,
+            enabled: org.branding_enabled,
+        };
+
+        await this.setCache(this.getCacheKey(orgId), config);
+
+        return config;
+    }
+
+    private async setCache(key: string, value: IBrandingConfig | null): Promise<void> {
+        try {
+            if (value === null) {
+                await this.redis.setex(key, BRANDING_CACHE_TTL, JSON.stringify(null));
+            } else {
+                await this.redis.setex(key, BRANDING_CACHE_TTL, JSON.stringify(value));
+            }
+        } catch (err) {
+            console.warn('[BrandingService] Redis write failed:', err);
+        }
+    }
+
+    /**
+     * Invalidate branding cache for an org. Call after tier changes, branding updates, etc.
+     */
+    async invalidateCache(orgId: number): Promise<void> {
+        try {
+            await this.redis.del(this.getCacheKey(orgId));
+        } catch (err) {
+            console.warn('[BrandingService] Cache invalidation failed:', err);
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - docker_test_network
     env_file:
       - ./.env
+      - ./backend/.env
     environment:
       - "VIRTUAL_HOST=backend.dataresearchanalysis.test"
     container_name: backend.dataresearchanalysis.test

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -14,8 +14,9 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 20 and npm using NodeSource repository
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+# Install Node.js 24.x and npm using NodeSource repository
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+    rm -f /etc/apt/sources.list.d/nodesource.list && \
     apt-get install -y nodejs
 
 # Install PostgreSQL 18 client tools for database backup/restore

--- a/docker/backend/entrypoint.sh
+++ b/docker/backend/entrypoint.sh
@@ -12,24 +12,14 @@ fi
 # Fix permissions and ownership for the public/uploads/pdfs folder after volume mount
 if [ -d "public/uploads/pdfs" ]; then
     echo "Setting up permissions for public/uploads/pdfs folder..."
-
-    # Set directory permissions to 755 (readable/executable by all, writable by owner)
     find public/uploads/pdfs -type d -exec chmod 755 {} \;
-
-    # Set file permissions to 755 (readable by all, writable by owner)  
     find public/uploads/pdfs -type f -exec chmod 755 {} \;
-
-    # Change ownership to appuser (requires root) - use correct relative path
     chown -R appuser:appuser public/uploads/pdfs
-    
     echo "Fixed permissions and ownership for public/uploads/pdf folder"
     ls -la public/uploads/pdfs
 else
     echo "public/uploads/pdfs folder not found"
 fi
-
-# Fix ownership of all files including node_modules before switching to appuser
-chown -R appuser:appuser /backend 2>/dev/null || true
 
 # Switch to appuser and execute the remaining commands
 exec su appuser -c "

--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -1,10 +1,21 @@
 @import "tailwindcss";
+
+:root {
+    --brand-primary: #3C8DBC;
+    --brand-primary-100: #3C8DBC;
+    --brand-primary-200: #367FA9;
+    --brand-primary-300: #307095;
+    --brand-primary-400: #296282;
+    --brand-primary-500: #23536F;
+    --brand-secondary: #1E3050;
+}
+
 @theme {
-    --color-primary-blue-100: #3C8DBC;
-    --color-primary-blue-200: #367FA9;
-    --color-primary-blue-300: #307095;
-    --color-primary-blue-400: #296282;
-    --color-primary-blue-500: #23536F;
+    --color-primary-blue-100: var(--brand-primary-100);
+    --color-primary-blue-200: var(--brand-primary-200);
+    --color-primary-blue-300: var(--brand-primary-300);
+    --color-primary-blue-400: var(--brand-primary-400);
+    --color-primary-blue-500: var(--brand-primary-500);
 }
 
 @layer base {
@@ -54,4 +65,59 @@
         60% 100%,
         0% 100%
   );
+}
+
+@media print {
+    @page {
+        margin: 0.5in;
+        size: A4;
+    }
+
+    body {
+        background-color: #ffffff !important;
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+    }
+
+    .print\:hidden {
+        display: none !important;
+    }
+
+    .print\:block {
+        display: block !important;
+    }
+
+    .print\:flex {
+        display: flex !important;
+    }
+
+    .print\:inline {
+        display: inline !important;
+    }
+
+    /* Reduce spacing for print */
+    .print-spacing {
+        padding-top: 12px !important;
+        padding-bottom: 12px !important;
+        margin-bottom: 12px !important;
+        margin-top: 12px !important;
+    }
+
+    .print-spacing-sm {
+        padding-top: 8px !important;
+        padding-bottom: 8px !important;
+        margin-bottom: 8px !important;
+        margin-top: 8px !important;
+    }
+
+    /* Keep embeds reasonable on paper */
+    iframe {
+        max-width: 100% !important;
+        height: 500px !important;
+    }
+
+    .public-report-item {
+        page-break-inside: avoid;
+        margin-bottom: 16px !important;
+    }
 }

--- a/frontend/components/admin/SubscriptionTierForm.vue
+++ b/frontend/components/admin/SubscriptionTierForm.vue
@@ -22,6 +22,9 @@ const formData = reactive({
     ai_generations_per_month: props.tier?.ai_generations_per_month || undefined as number | undefined,
     price_per_month_usd: props.tier?.price_per_month_usd !== undefined ? parseFloat(props.tier.price_per_month_usd) : undefined as number | undefined,
     price_per_year_usd: props.tier?.price_per_year_usd !== undefined && props.tier.price_per_year_usd !== null ? parseFloat(props.tier.price_per_year_usd) : undefined as number | undefined,
+    paddle_product_id: props.tier?.paddle_product_id || '',
+    paddle_price_id_monthly: props.tier?.paddle_price_id_monthly || '',
+    paddle_price_id_annual: props.tier?.paddle_price_id_annual || '',
     is_active: props.tier?.is_active !== undefined ? props.tier.is_active : true,
 });
 
@@ -301,23 +304,29 @@ function setNull(field: string) {
             </div>
         </BaseFormField>
 
-        <!-- Paddle Integration Fields (read-only — auto-populated on create) -->
-        <div v-if="props.tier?.paddle_product_id" class="border-t pt-4 mt-6">
+        <!-- Paddle Integration Fields (editable) -->
+        <div class="border-t pt-4 mt-6">
             <h3 class="text-lg font-semibold text-gray-900 mb-1">Paddle IDs</h3>
-            <p class="text-xs text-gray-500 mb-3">Auto-assigned when this tier was created. Read-only.</p>
-            <div class="grid grid-cols-1 gap-2 text-sm">
-                <div class="flex justify-between bg-gray-50 rounded px-3 py-2">
-                    <span class="text-gray-600">Product ID</span>
-                    <span class="font-mono text-gray-900">{{ props.tier.paddle_product_id }}</span>
-                </div>
-                <div v-if="props.tier.paddle_price_id_monthly" class="flex justify-between bg-gray-50 rounded px-3 py-2">
-                    <span class="text-gray-600">Monthly Price ID</span>
-                    <span class="font-mono text-gray-900">{{ props.tier.paddle_price_id_monthly }}</span>
-                </div>
-                <div v-if="props.tier.paddle_price_id_annual" class="flex justify-between bg-gray-50 rounded px-3 py-2">
-                    <span class="text-gray-600">Annual Price ID</span>
-                    <span class="font-mono text-gray-900">{{ props.tier.paddle_price_id_annual }}</span>
-                </div>
+            <p class="text-xs text-gray-500 mb-3">Configure Paddle product and price IDs for this tier. Leave blank for Free tier.</p>
+            <div class="space-y-3">
+                <BaseFormField label="Product ID" :required="false">
+                    <BaseInput
+                        v-model="formData.paddle_product_id"
+                        placeholder="e.g., pro_01hx9kz..."
+                    />
+                </BaseFormField>
+                <BaseFormField label="Monthly Price ID" :required="false">
+                    <BaseInput
+                        v-model="formData.paddle_price_id_monthly"
+                        placeholder="e.g., pri_01hx9kz..."
+                    />
+                </BaseFormField>
+                <BaseFormField label="Annual Price ID" :required="false">
+                    <BaseInput
+                        v-model="formData.paddle_price_id_annual"
+                        placeholder="e.g., pri_01hx9kz..."
+                    />
+                </BaseFormField>
             </div>
         </div>
 

--- a/frontend/components/organization-switcher.vue
+++ b/frontend/components/organization-switcher.vue
@@ -237,8 +237,16 @@ function closeSettingsModal() {
                             <p class="text-sm text-gray-500">No organizations available</p>
                         </div>
                         
-                        <!-- Footer - Create New Organization -->
-                        <div class="px-4 py-2 bg-gray-50 border-t border-gray-200">
+                        <!-- Footer - Branding & Create -->
+                        <div class="px-4 py-2 bg-gray-50 border-t border-gray-200 space-y-1">
+                            <NuxtLink
+                                v-if="currentOrganization && (currentOrganization.user_role === 'owner' || currentOrganization.user_role === 'admin')"
+                                to="/organizations/settings/branding"
+                                class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded transition-colors flex items-center gap-2"
+                            >
+                                <font-awesome-icon :icon="['fas', 'palette']" />
+                                <span>Branding</span>
+                            </NuxtLink>
                             <button 
                                 type="button"
                                 @click="openCreateModal"

--- a/frontend/composables/useBranding.ts
+++ b/frontend/composables/useBranding.ts
@@ -1,0 +1,105 @@
+export interface IBrandingConfig {
+    primaryColor: string | null;
+    secondaryColor: string | null;
+    logoUrl: string | null;
+    enabled: boolean;
+}
+
+function hexToHsl(hex: string): { h: number; s: number; l: number } {
+    const r = parseInt(hex.slice(1, 3), 16) / 255;
+    const g = parseInt(hex.slice(3, 5), 16) / 255;
+    const b = parseInt(hex.slice(5, 7), 16) / 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+
+    let h = 0;
+    let s = 0;
+
+    if (max !== min) {
+        const d = max - min;
+        s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+        switch (max) {
+            case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+            case g: h = ((b - r) / d + 2) / 6; break;
+            case b: h = ((r - g) / d + 4) / 6; break;
+        }
+    }
+
+    return {
+        h: Math.round(h * 360),
+        s: Math.round(s * 100),
+        l: Math.round(l * 100),
+    };
+}
+
+function derivePalette(hex: string): Record<string, string> {
+    const { h, s, l } = hexToHsl(hex);
+    return {
+        '--brand-primary-100': hex,
+        '--brand-primary-200': `hsl(${h}, ${Math.max(0, s - 5)}%, ${Math.min(100, l - 5)}%)`,
+        '--brand-primary-300': `hsl(${h}, ${Math.max(0, s - 10)}%, ${Math.min(100, l - 10)}%)`,
+        '--brand-primary-400': `hsl(${h}, ${Math.max(0, s - 15)}%, ${Math.min(100, l - 15)}%)`,
+        '--brand-primary-500': `hsl(${h}, ${Math.max(0, s - 20)}%, ${Math.min(100, l - 20)}%)`,
+    };
+}
+
+export function useBranding() {
+    const config = useRuntimeConfig();
+    const apiUrl = config.public.apiBase;
+
+    function applyBranding(branding: IBrandingConfig | null | undefined): void {
+        if (!branding?.enabled) {
+            resetBranding();
+            return;
+        }
+
+        const root = document.documentElement;
+
+        if (branding.primaryColor) {
+            root.style.setProperty('--brand-primary', branding.primaryColor);
+            const palette = derivePalette(branding.primaryColor);
+            Object.entries(palette).forEach(([key, value]) => {
+                root.style.setProperty(key, value);
+            });
+        }
+
+        if (branding.secondaryColor) {
+            root.style.setProperty('--brand-secondary', branding.secondaryColor);
+        }
+    }
+
+    function resetBranding(): void {
+        const root = document.documentElement;
+        const defaults: Record<string, string> = {
+            '--brand-primary': '#3C8DBC',
+            '--brand-primary-100': '#3C8DBC',
+            '--brand-primary-200': '#367FA9',
+            '--brand-primary-300': '#307095',
+            '--brand-primary-400': '#296282',
+            '--brand-primary-500': '#23536F',
+            '--brand-secondary': '#1E3050',
+        };
+        Object.entries(defaults).forEach(([key, value]) => {
+            root.style.setProperty(key, value);
+        });
+    }
+
+    async function fetchBranding(orgId: number): Promise<IBrandingConfig | null> {
+        try {
+            const data = await $fetch<{ success: boolean; data: IBrandingConfig | null }>(
+                `${apiUrl}/organizations/${orgId}/branding`
+            );
+            return data?.data ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    return {
+        applyBranding,
+        resetBranding,
+        fetchBranding,
+    };
+}

--- a/frontend/composables/usePublicDashboard.ts
+++ b/frontend/composables/usePublicDashboard.ts
@@ -6,6 +6,12 @@ interface IPublicDashboardData {
   dashboard: IDashboard;
   project: IProject;
   key?: string;
+  branding?: {
+    primaryColor: string | null;
+    secondaryColor: string | null;
+    logoUrl: string | null;
+    enabled: boolean;
+  } | null;
 }
 
 export const usePublicDashboard = (dashboardKey: string) => {

--- a/frontend/composables/useReports.ts
+++ b/frontend/composables/useReports.ts
@@ -69,14 +69,14 @@ export const useReports = () => {
         }
     };
 
-    const getPublicReport = async (key: string): Promise<IReport | null> => {
+    const getPublicReport = async (key: string): Promise<{ report: IReport; branding: any } | null> => {
         try {
             // Generate token for public access (non-auth pattern)
             const tokenUrl = `${config.public.apiBase}/generate-token`;
             const responseToken = await $fetch<any>(tokenUrl);
             const token = responseToken.token;
             
-            const response = await $fetch<{ success: boolean; report: IReport }>(
+            const response = await $fetch<{ success: boolean; report: IReport; branding: any }>(
                 `${config.public.apiBase}/reports/public/${key}`,
                 {
                     headers: {
@@ -85,7 +85,7 @@ export const useReports = () => {
                     },
                 },
             );
-            return response?.success ? response.report : null;
+            return response?.success ? response : null;
         } catch (error) {
             console.error('[useReports] getPublicReport failed:', error);
             return null;

--- a/frontend/pages/organizations/settings/branding.vue
+++ b/frontend/pages/organizations/settings/branding.vue
@@ -1,0 +1,371 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'default' });
+
+import { getAuthToken } from '~/composables/AuthToken';
+import { useOrganizationContext } from '@/composables/useOrganizationContext';
+
+const { getOrgId, getHeaders } = useOrganizationContext();
+const router = useRouter();
+
+const config = useRuntimeConfig();
+const apiUrl = config.public.apiBase;
+
+const orgId = ref<number | null>(null);
+const orgName = ref('');
+const isLoading = ref(true);
+const isSaving = ref(false);
+const isUploading = ref(false);
+const error = ref('');
+const successMessage = ref('');
+
+const primaryColor = ref('#3C8DBC');
+const secondaryColor = ref('#1E3050');
+const brandingEnabled = ref(false);
+const logoUrl = ref('');
+
+const eligible = ref(false);
+const tierName = ref('');
+const tierRank = ref(0);
+
+async function loadOrg() {
+    isLoading.value = true;
+    error.value = '';
+
+    const headers = getHeaders();
+
+    try {
+        const orgsData = await $fetch<{ success: boolean; data: any[] }>(`${apiUrl}/organizations`, {
+            headers,
+        });
+        const orgs = orgsData?.data ?? [];
+
+        if (orgs.length === 0) {
+            error.value = 'No organization found.';
+            return;
+        }
+
+        const selectedOrgId = getOrgId() ?? orgs[0].id;
+        orgId.value = selectedOrgId;
+
+        const org = orgs.find((o: any) => o.id === selectedOrgId);
+        if (org) {
+            orgName.value = org.name;
+        }
+
+        const sub = await $fetch<{ success: boolean; data: any }>(
+            `${apiUrl}/subscription/${selectedOrgId}`, { headers }
+        );
+        const subData = sub?.data;
+        tierRank.value = subData?.tier_rank ?? 0;
+        tierName.value = subData?.tier_name ?? 'Free';
+        eligible.value = tierRank.value >= 30;
+
+        const brandingData = await $fetch<{ success: boolean; data: any }>(
+            `${apiUrl}/organizations/${selectedOrgId}/branding`
+        );
+        const branding = brandingData?.data;
+        if (branding) {
+            primaryColor.value = branding.primaryColor ?? '#3C8DBC';
+            secondaryColor.value = branding.secondaryColor ?? '#1E3050';
+            brandingEnabled.value = branding.enabled ?? false;
+            logoUrl.value = branding.logoUrl ?? '';
+        }
+    } catch (err: any) {
+        error.value = err?.data?.message ?? err?.message ?? 'Failed to load organization settings';
+    } finally {
+        isLoading.value = false;
+    }
+}
+
+async function handleLogoUpload(file: File) {
+    if (!file) return;
+    isUploading.value = true;
+    error.value = '';
+
+    try {
+        const token = getAuthToken();
+        const formData = new FormData();
+        formData.append('image', file);
+
+        const response = await fetch(`${apiUrl}/admin/image/upload`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Authorization-Type': 'auth',
+            },
+            body: formData,
+        });
+
+        if (!response.ok) {
+            throw new Error('Logo upload failed');
+        }
+
+        const data = await response.json();
+        if (data.urls && data.urls.length > 0 && data.urls[0].url) {
+            logoUrl.value = data.urls[0].url;
+        }
+    } catch (err: any) {
+        error.value = err?.message ?? 'Failed to upload logo.';
+    } finally {
+        isUploading.value = false;
+    }
+}
+
+async function saveBranding() {
+    if (!orgId.value) return;
+    isSaving.value = true;
+    error.value = '';
+    successMessage.value = '';
+
+    try {
+        const headers = getHeaders();
+        await $fetch(`${apiUrl}/organizations/${orgId.value}/branding`, {
+            method: 'PUT',
+            headers,
+            body: JSON.stringify({
+                primaryColor: primaryColor.value || null,
+                secondaryColor: secondaryColor.value || null,
+                brandingEnabled: brandingEnabled.value,
+                logoUrl: logoUrl.value || null,
+            }),
+        });
+        successMessage.value = 'Branding settings saved successfully.';
+        setTimeout(() => { successMessage.value = ''; }, 3000);
+    } catch (err: any) {
+        error.value = err?.data?.message ?? err?.message ?? 'Failed to save branding settings';
+    } finally {
+        isSaving.value = false;
+    }
+}
+
+onMounted(() => {
+    loadOrg();
+});
+</script>
+
+<template>
+    <div class="min-h-screen bg-gray-50">
+        <div class="max-w-3xl mx-auto px-4 py-10">
+            <div class="mb-8">
+                <button
+                    class="inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 mb-4 cursor-pointer"
+                    @click="router.back()"
+                >
+                    <font-awesome-icon :icon="['fas', 'arrow-left']" class="mr-2" />
+                    Back
+                </button>
+                <h1 class="text-3xl font-bold text-gray-900">Custom Branding</h1>
+                <p class="mt-2 text-sm text-gray-500">
+                    Customize how your public reports and dashboards look. Your branding will appear on all shared reports, dashboards, and exports.
+                </p>
+            </div>
+
+            <div v-if="isLoading" class="flex justify-center items-center py-12">
+                <div class="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-blue-500" />
+            </div>
+
+            <div v-else-if="!eligible" class="bg-white border rounded-lg p-8 text-center">
+                <font-awesome-icon :icon="['fas', 'palette']" class="text-4xl text-gray-300 mb-4" />
+                <h2 class="text-lg font-semibold text-gray-700 mb-2">Upgrade Required</h2>
+                <p class="text-sm text-gray-500 mb-6 max-w-md mx-auto">
+                    Custom branding is available on the <strong>Professional Plus</strong> plan and above.
+                    Upgrade your plan to add your own logo and colors to public reports and dashboards.
+                </p>
+                <NuxtLink
+                    to="/pricing"
+                    class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors cursor-pointer text-sm font-medium"
+                >
+                    View Plans
+                </NuxtLink>
+            </div>
+
+            <div v-else class="space-y-6">
+                <div v-if="error" class="bg-red-50 border border-red-200 rounded-lg p-4">
+                    <p class="text-red-800 text-sm">{{ error }}</p>
+                </div>
+
+                <div v-if="successMessage" class="bg-green-50 border border-green-200 rounded-lg p-4">
+                    <p class="text-green-800 text-sm">{{ successMessage }}</p>
+                </div>
+
+                <div class="bg-white border rounded-lg p-6">
+                    <h2 class="text-lg font-semibold text-gray-900 mb-4">Branding Configuration</h2>
+
+                    <div class="space-y-6">
+                        <div class="flex items-start justify-between">
+                            <div>
+                                <label class="font-medium text-gray-800 text-sm">Enable Custom Branding</label>
+                                <p class="text-xs text-gray-500 mt-1">
+                                    When enabled, your colors and logo will appear on all public reports and dashboards.
+                                </p>
+                            </div>
+                            <label class="relative inline-flex items-center cursor-pointer shrink-0">
+                                <input v-model="brandingEnabled" type="checkbox" class="sr-only peer" />
+                                <div
+                                    class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"
+                                />
+                            </label>
+                        </div>
+
+                        <div class="border-t pt-6">
+                            <label class="block font-medium text-gray-800 text-sm mb-2">Logo</label>
+                            <p class="text-xs text-gray-500 mb-3">
+                                Upload your logo image. Recommended size: 200×40px, PNG or SVG.
+                            </p>
+                            <div class="space-y-3">
+                                <div v-if="logoUrl" class="flex items-center gap-3">
+                                    <img
+                                        :src="logoUrl"
+                                        class="h-8 w-auto object-contain border rounded p-1"
+                                        alt="Current logo"
+                                    />
+                                    <button
+                                        type="button"
+                                        class="text-xs text-red-600 hover:text-red-800 cursor-pointer"
+                                        @click="logoUrl = ''"
+                                    >
+                                        Remove
+                                    </button>
+                                </div>
+                                <div class="flex items-center gap-3">
+                                    <label
+                                        class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50 cursor-pointer transition-colors"
+                                        :class="{ 'opacity-50 pointer-events-none': isUploading }"
+                                    >
+                                        <font-awesome-icon
+                                            v-if="isUploading"
+                                            :icon="['fas', 'spinner']"
+                                            class="animate-spin"
+                                        />
+                                        <font-awesome-icon v-else :icon="['fas', 'upload']" />
+                                        {{ isUploading ? 'Uploading...' : 'Upload Logo' }}
+                                        <input
+                                            type="file"
+                                            accept="image/png,image/jpeg,image/svg+xml,image/gif,image/webp"
+                                            class="hidden"
+                                            @change="(e) => { const f = (e.target as HTMLInputElement).files?.[0]; if (f) handleLogoUpload(f); }"
+                                        />
+                                    </label>
+                                    <span class="text-xs text-gray-400">or</span>
+                                    <input
+                                        v-model="logoUrl"
+                                        type="url"
+                                        class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                        placeholder="https://example.com/logo.png"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="border-t pt-6">
+                            <label class="block font-medium text-gray-800 text-sm mb-2">Primary Color</label>
+                            <p class="text-xs text-gray-500 mb-3">
+                                Used for headers, buttons, and primary accents in public pages.
+                            </p>
+                            <div class="flex items-center gap-3">
+                                <input
+                                    v-model="primaryColor"
+                                    type="color"
+                                    class="w-10 h-10 rounded border border-gray-300 cursor-pointer p-0.5"
+                                />
+                                <input
+                                    v-model="primaryColor"
+                                    type="text"
+                                    class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                    placeholder="#3C8DBC"
+                                    pattern="^#[0-9A-Fa-f]{6}$"
+                                    maxlength="7"
+                                />
+                            </div>
+                        </div>
+
+                        <div class="border-t pt-6">
+                            <label class="block font-medium text-gray-800 text-sm mb-2">Secondary Color</label>
+                            <p class="text-xs text-gray-500 mb-3">
+                                Used for secondary accents and subtle highlights.
+                            </p>
+                            <div class="flex items-center gap-3">
+                                <input
+                                    v-model="secondaryColor"
+                                    type="color"
+                                    class="w-10 h-10 rounded border border-gray-300 cursor-pointer p-0.5"
+                                />
+                                <input
+                                    v-model="secondaryColor"
+                                    type="text"
+                                    class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                    placeholder="#1E3050"
+                                    pattern="^#[0-9A-Fa-f]{6}$"
+                                    maxlength="7"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="bg-white border rounded-lg p-6">
+                    <h2 class="text-lg font-semibold text-gray-900 mb-4">Preview</h2>
+                    <p class="text-xs text-gray-500 mb-6">
+                        This is a live preview of how your public report header will look.
+                    </p>
+
+                    <div class="rounded-lg overflow-hidden border">
+                        <div
+                            class="px-4 py-3 flex items-center justify-between"
+                            :style="brandingEnabled ? { backgroundColor: primaryColor } : { backgroundColor: '#3C8DBC' }"
+                        >
+                            <div class="flex items-center gap-3">
+                                <img
+                                    v-if="brandingEnabled && logoUrl"
+                                    :src="logoUrl"
+                                    class="h-5 w-auto object-contain"
+                                    alt="Logo preview"
+                                    @error="(e) => { (e.target as HTMLImageElement).style.display = 'none'; }"
+                                />
+                                <font-awesome-icon
+                                    v-else
+                                    :icon="['fas', 'chart-bar']"
+                                    class="text-lg"
+                                    :class="brandingEnabled ? 'text-white/70' : 'text-white/70'"
+                                />
+                                <span
+                                    class="text-sm font-medium"
+                                    :style="brandingEnabled ? { color: secondaryColor } : {}"
+                                    :class="brandingEnabled ? '' : 'text-white/80'"
+                                >
+                                    {{ orgName || 'Your Organization' }} — Report
+                                </span>
+                            </div>
+                            <span
+                                class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md"
+                                :style="brandingEnabled ? { backgroundColor: secondaryColor + '30', color: secondaryColor } : { backgroundColor: '#ffffff20', color: '#ffffff99' }"
+                            >
+                                <font-awesome-icon :icon="['fas', 'circle-check']" />
+                                Published
+                            </span>
+                        </div>
+                        <div class="bg-white px-4 py-8">
+                            <div class="flex flex-col items-center justify-center text-center py-6">
+                                <p class="text-sm text-gray-400">
+                                    Report content will appear here using your brand colors for accents and buttons.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex justify-end">
+                    <button
+                        type="button"
+                        :disabled="isSaving"
+                        class="inline-flex items-center px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors cursor-pointer text-sm font-medium disabled:opacity-50"
+                        @click="saveBranding"
+                    >
+                        <font-awesome-icon v-if="isSaving" :icon="['fas', 'spinner']" class="animate-spin mr-2" />
+                        {{ isSaving ? 'Saving...' : 'Save Branding Settings' }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/frontend/pages/projects/[projectid]/reports/[reportid]/edit.vue
+++ b/frontend/pages/projects/[projectid]/reports/[reportid]/edit.vue
@@ -140,12 +140,6 @@ async function confirmDelete() {
   }
 }
 
-function printReport() {
-  if (import.meta.client) {
-    window.print()
-  }
-}
-
 function onShareUpdated(updated: IReport) {
   if (report.value) {
     report.value = { ...report.value, share_key: updated.share_key, share_expires_at: updated.share_expires_at }
@@ -219,13 +213,6 @@ onUnmounted(() => {
 
           <!-- Right: actions -->
           <div class="flex items-center gap-2 shrink-0 flex-wrap justify-end">
-            <button
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
-              @click="printReport"
-            >
-              <font-awesome-icon :icon="['fas', 'print']" />
-              Print / PDF
-            </button>
             <button
               v-if="canEdit"
               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"

--- a/frontend/pages/public-dashboard/[dashboardkey].vue
+++ b/frontend/pages/public-dashboard/[dashboardkey].vue
@@ -3,6 +3,7 @@ import { onBeforeUnmount } from 'vue';
 import { useProjectsStore } from '@/stores/projects';
 import { useDataModelsStore } from '@/stores/data_models';
 import { useDashboardsStore } from '@/stores/dashboards';
+import { useBranding } from '@/composables/useBranding';
 import _ from 'lodash';
 
 definePageMeta({
@@ -13,12 +14,25 @@ const projectsStore = useProjectsStore();
 const dataModelsStore = useDataModelsStore();
 const dashboardsStore = useDashboardsStore();
 const { $swal, $htmlToImageToPng } = useNuxtApp();
+const { applyBranding } = useBranding();
 const router = useRouter();
 const route = useRoute();
 const dashboardKey = String(route.params.dashboardkey);
 
 // Fetch dashboard with SSR support
 const { dashboardData, pending, error } = await usePublicDashboard(dashboardKey);
+
+const branding = computed(() => {
+    const data = dashboardData.value as any;
+    return data?.branding ?? null;
+});
+
+// Apply branding on client side
+watchEffect(() => {
+    if (import.meta.client && branding.value) {
+        applyBranding(branding.value);
+    }
+});
 
 // Computed dashboard from SSR data or store
 const dashboard = computed(() => {
@@ -46,54 +60,61 @@ watchEffect(() => {
 });
 
 // Set up dynamic meta tags based on dashboard data
-useHead(() => ({
-    title: dashboard.value?.name 
-        ? `${dashboard.value.name} - Data Dashboard | Data Research Analysis`
-        : 'Public Dashboard | Data Research Analysis',
-    meta: [
-        { 
-            name: 'description', 
-            content: dashboard.value?.description 
-                || `Interactive data dashboard for ${project.value?.name || 'data analysis'}. Explore visualizations and insights powered by Data Research Analysis.` 
-        },
-        { name: 'robots', content: 'index, follow' },
-        
-        // Open Graph / Facebook
-        { property: 'og:type', content: 'website' },
-        { property: 'og:url', content: `https://www.dataresearchanalysis.com/public-dashboard/${route.params.dashboardkey}` },
-        { 
-            property: 'og:title', 
-            content: dashboard.value?.name 
-                ? `${dashboard.value.name} - Data Dashboard`
-                : 'Public Data Dashboard' 
-        },
-        { 
-            property: 'og:description', 
-            content: dashboard.value?.description 
-                || `Interactive data dashboard with real-time visualizations and analytics.` 
-        },
-        { property: 'og:image', content: 'https://api.dataresearchanalysis.com/uploads/image-1782329307800-54137128.png' },
-        
-        // Twitter
-        { name: 'twitter:card', content: 'summary_large_image' },
-        { name: 'twitter:url', content: `https://dataresearchanalysis.com/public-dashboard/${route.params.dashboardkey}` },
-        { 
-            name: 'twitter:title', 
-            content: dashboard.value?.name 
-                ? `${dashboard.value.name} - Data Dashboard`
-                : 'Public Data Dashboard' 
-        },
-        { 
-            name: 'twitter:description', 
-            content: dashboard.value?.description 
-                || `Interactive data dashboard with real-time visualizations.` 
-        },
-        { name: 'twitter:image', content: 'https://dataresearchanalysis.com/images/dashboard-preview.png' },
-    ],
-    link: [
-        { rel: 'canonical', href: `https://www.dataresearchanalysis.com/public-dashboard/${route.params.dashboardkey}` }
-    ]
-}));
+useHead(() => {
+    const brandLogo = branding.value?.enabled && branding.value?.logoUrl 
+        ? branding.value.logoUrl 
+        : 'https://api.dataresearchanalysis.com/uploads/image-1782329307800-54137128.png';
+    const twitterLogo = branding.value?.enabled && branding.value?.logoUrl 
+        ? branding.value.logoUrl 
+        : 'https://dataresearchanalysis.com/images/dashboard-preview.png';
+
+    return {
+        title: dashboard.value?.name 
+            ? `${dashboard.value.name} - Data Dashboard | Data Research Analysis`
+            : 'Public Dashboard | Data Research Analysis',
+        meta: [
+            { 
+                name: 'description', 
+                content: dashboard.value?.description 
+                    || `Interactive data dashboard for ${project.value?.name || 'data analysis'}. Explore visualizations and insights powered by Data Research Analysis.` 
+            },
+            { name: 'robots', content: 'index, follow' },
+            
+            { property: 'og:type', content: 'website' },
+            { property: 'og:url', content: `https://www.dataresearchanalysis.com/public-dashboard/${route.params.dashboardkey}` },
+            { 
+                property: 'og:title', 
+                content: dashboard.value?.name 
+                    ? `${dashboard.value.name} - Data Dashboard`
+                    : 'Public Data Dashboard' 
+            },
+            { 
+                property: 'og:description', 
+                content: dashboard.value?.description 
+                    || `Interactive data dashboard with real-time visualizations and analytics.` 
+            },
+            { property: 'og:image', content: brandLogo },
+            
+            { name: 'twitter:card', content: 'summary_large_image' },
+            { name: 'twitter:url', content: `https://dataresearchanalysis.com/public-dashboard/${route.params.dashboardkey}` },
+            { 
+                name: 'twitter:title', 
+                content: dashboard.value?.name 
+                    ? `${dashboard.value.name} - Data Dashboard`
+                    : 'Public Data Dashboard' 
+            },
+            { 
+                name: 'twitter:description', 
+                content: dashboard.value?.description 
+                    || `Interactive data dashboard with real-time visualizations.` 
+            },
+            { name: 'twitter:image', content: twitterLogo },
+        ],
+        link: [
+            { rel: 'canonical', href: `https://www.dataresearchanalysis.com/public-dashboard/${route.params.dashboardkey}` }
+        ]
+    };
+});
 
 interface State {
     data_model_tables: any[];
@@ -867,7 +888,6 @@ async function executeQueryOnDataModels(chartId: string) {
 
 // Pre-export preparation function to handle overflow containers
 function prepareForExport() {
-    // Only access DOM on client side for SSR compatibility
     if (!import.meta.client) return null;
     
     const dashboardContainer = document.querySelector('.data-research-analysis') as HTMLElement | null;
@@ -875,42 +895,116 @@ function prepareForExport() {
     
     if (!dashboardContainer) return null;
     
-    // Save original styles for dashboard container
     const originalStyles = {
         overflow: dashboardContainer.style.overflow || '',
         overflowX: dashboardContainer.style.overflowX || '',
         overflowY: dashboardContainer.style.overflowY || ''
     };
     
-    // Make overflow visible for export
     dashboardContainer.style.overflow = 'visible';
     dashboardContainer.style.overflowX = 'visible';
     dashboardContainer.style.overflowY = 'visible';
     
-    // Show export branding
+    const exportHeader = document.createElement('div');
+    exportHeader.className = 'export-header';
+    exportHeader.style.cssText = `
+        width: 100%;
+        padding: 16px 24px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border-bottom: 1px solid transparent;
+        box-sizing: border-box;
+    `;
+    if (branding.value?.enabled && branding.value?.primaryColor) {
+        exportHeader.style.backgroundColor = branding.value.primaryColor;
+    } else {
+        exportHeader.style.backgroundColor = '#ffffff';
+        exportHeader.style.borderColor = '#e5e7eb';
+    }
+    
+    const leftSide = document.createElement('div');
+    leftSide.style.cssText = 'display: flex; align-items: center; gap: 12px;';
+    
+    if (branding.value?.enabled && branding.value?.logoUrl) {
+        const logoImg = document.createElement('img');
+        logoImg.src = branding.value.logoUrl;
+        logoImg.style.cssText = 'height: 24px; width: auto; object-fit: contain; display: block;';
+        logoImg.alt = 'Logo';
+        logoImg.crossOrigin = 'anonymous';
+        leftSide.appendChild(logoImg);
+    }
+    
+    const titleSpan = document.createElement('span');
+    titleSpan.textContent = dashboard.value?.name || 'Public Dashboard';
+    titleSpan.style.cssText = `
+        font-size: 24px;
+        font-weight: 700;
+        line-height: 1.2;
+    `;
+    if (branding.value?.enabled) {
+        titleSpan.style.color = '#ffffff';
+    } else {
+        titleSpan.style.color = '#111827';
+    }
+    leftSide.appendChild(titleSpan);
+    
+    exportHeader.appendChild(leftSide);
+    
+    const rightSide = document.createElement('div');
+    rightSide.style.cssText = 'display: flex; align-items: center; gap: 12px;';
+    
+    const chartsBadge = document.createElement('span');
+    chartsBadge.textContent = `${charts.value.length} ${charts.value.length === 1 ? 'Chart' : 'Charts'}`;
+    chartsBadge.style.cssText = `
+        padding: 4px 10px;
+        font-size: 12px;
+        font-weight: 500;
+        border-radius: 9999px;
+    `;
+    if (branding.value?.enabled) {
+        chartsBadge.style.color = '#ffffffcc';
+        chartsBadge.style.backgroundColor = '#ffffff1a';
+    } else {
+        chartsBadge.style.color = '#6b7280';
+        chartsBadge.style.backgroundColor = '#f3f4f6';
+    }
+    rightSide.appendChild(chartsBadge);
+    
+    exportHeader.appendChild(rightSide);
+    
+    dashboardContainer.insertBefore(exportHeader, dashboardContainer.firstChild);
+    
     if (exportBranding) {
+        const orgName = branding.value?.enabled ? (dashboard.value?.project?.organization?.name || '') : '';
+        const poweredBy = exportBranding.querySelector('.powered-by-line') as HTMLElement | null;
+        if (poweredBy && orgName) {
+            poweredBy.textContent = `Powered by ${orgName}`;
+        }
         exportBranding.classList.remove('hidden');
     }
     
     return { 
         dashboardContainer, 
         exportBranding,
+        exportHeader,
         originalStyles
     };
 }
 
-// Post-export restoration function
 function restoreOriginalStyles(preparation: any) {
     if (!preparation || !preparation.dashboardContainer || !preparation.originalStyles) return;
     
-    const { dashboardContainer, exportBranding, originalStyles } = preparation;
+    const { dashboardContainer, exportBranding, exportHeader, originalStyles } = preparation;
     
-    // Restore dashboard container styles
     dashboardContainer.style.overflow = originalStyles.overflow;
     dashboardContainer.style.overflowX = originalStyles.overflowX;
     dashboardContainer.style.overflowY = originalStyles.overflowY;
     
-    // Hide export branding again
+    if (exportHeader && exportHeader.parentNode) {
+        exportHeader.parentNode.removeChild(exportHeader);
+    }
+    
     if (exportBranding) {
         exportBranding.classList.add('hidden');
     }
@@ -1052,27 +1146,54 @@ onMounted(async () => {
     <!-- Main Dashboard -->
     <div v-else class="flex flex-col min-h-screen bg-gray-50">
         <!-- Professional Header -->
-        <header class="bg-white border-b border-gray-200 shadow-sm sticky top-0 z-50">
+        <header
+            class="border-b shadow-sm sticky top-0 z-50"
+            :style="branding?.enabled && branding?.primaryColor
+                ? { backgroundColor: branding.primaryColor, borderColor: 'transparent' }
+                : { backgroundColor: '#ffffff', borderColor: '#e5e7eb' }"
+        >
             <div class="max-w-[1800px] mx-auto px-6 py-4">
                 <div class="flex items-center justify-between">
                     <!-- Left: Dashboard Info -->
                     <div class="flex-1">
                         <div class="flex items-center gap-3 mb-1">
-                            <div class="w-10 h-10 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg flex items-center justify-center">
-                                <font-awesome icon="fas fa-chart-line" class="text-white text-lg" />
+                            <img
+                                v-if="branding?.enabled && branding?.logoUrl"
+                                :src="branding.logoUrl"
+                                class="h-6 w-auto object-contain"
+                                alt="Logo"
+                            />
+                            <div
+                                v-else
+                                class="w-10 h-10 rounded-lg flex items-center justify-center shrink-0 bg-gradient-to-br from-blue-500 to-indigo-600"
+                            >
+                                <font-awesome
+                                    icon="fas fa-chart-line"
+                                    class="text-lg text-white"
+                                />
                             </div>
                             <div>
-                                <h1 class="text-2xl font-bold text-gray-900">
+                                <h1
+                                    class="text-2xl font-bold"
+                                    :class="branding?.enabled ? 'text-white' : 'text-gray-900'"
+                                >
                                     {{ dashboard?.name || 'Public Dashboard' }}
                                 </h1>
-                                <p v-if="dashboard?.description" class="text-sm text-gray-600 mt-0.5">
+                                <p
+                                    v-if="dashboard?.description"
+                                    class="text-sm mt-0.5"
+                                    :class="branding?.enabled ? 'text-white/70' : 'text-gray-600'"
+                                >
                                     {{ dashboard.description }}
                                 </p>
                             </div>
                         </div>
-                        
+
                         <!-- Metadata badges -->
-                        <div class="flex items-center gap-4 mt-2 text-xs text-gray-500">
+                        <div
+                            class="flex items-center gap-4 mt-2 text-xs"
+                            :class="branding?.enabled ? 'text-white/60' : 'text-gray-500'"
+                        >
                             <span v-if="project?.name" class="flex items-center gap-1">
                                 <font-awesome icon="fas fa-folder" />
                                 {{ project.name }}
@@ -1083,13 +1204,17 @@ onMounted(async () => {
                             </span>
                         </div>
                     </div>
-                    
+
                     <!-- Right: Export Button -->
-                    <button 
+                    <button
                         @click="exportDashboardAsImage()"
-                        class="flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-all shadow-md hover:shadow-lg font-medium cursor-pointer">
-                        <font-awesome icon="fas fa-download" />
-                        <span>Export Dashboard</span>
+                        class="flex items-center gap-2 px-5 py-2.5 rounded-lg transition-all shadow-md hover:shadow-lg font-medium cursor-pointer"
+                        :class="branding?.enabled
+                            ? 'bg-white/15 text-white hover:bg-white/25'
+                            : 'bg-blue-600 text-white hover:bg-blue-700'"
+                    >
+                        <font-awesome icon="fas fa-image" />
+                        <span>Download as Image</span>
                     </button>
                 </div>
             </div>
@@ -1468,7 +1593,7 @@ onMounted(async () => {
                     <!-- Export Branding (appears in exported image only) -->
                     <div class="export-branding hidden absolute bottom-4 left-1/2 transform -translate-x-1/2 text-center">
                         <div class="text-xs text-gray-500">
-                            <div class="font-medium">Powered by Data Research Analysis</div>
+                            <div class="powered-by-line font-medium">Powered by Data Research Analysis</div>
                             <div class="text-blue-600 font-semibold mt-0.5">www.dataresearchanalysis.com</div>
                         </div>
                     </div>

--- a/frontend/pages/public-report/[key].vue
+++ b/frontend/pages/public-report/[key].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useReports, type IReport } from '@/composables/useReports';
+import { useBranding } from '@/composables/useBranding';
 import TextBlock from '@/components/report-items/TextBlock.vue';
 import AiInsightsSection from '@/components/report-items/AiInsightsSection.vue';
 import KpiCardRow from '@/components/report-items/KpiCardRow.vue';
@@ -9,9 +10,11 @@ definePageMeta({ layout: false });
 
 const route = useRoute();
 const reportsApi = useReports();
+const { applyBranding } = useBranding();
 const key = String(route.params.key);
 
 const report = ref<IReport | null>(null);
+const branding = ref<any | null>(null);
 const loading = ref(true);
 const notFound = ref(false);
 
@@ -21,7 +24,11 @@ async function load() {
     if (!data) {
         notFound.value = true;
     } else {
-        report.value = data;
+        report.value = data.report;
+        branding.value = data.branding ?? null;
+        if (import.meta.client && branding.value) {
+            applyBranding(branding.value);
+        }
     }
     loading.value = false;
 }
@@ -30,9 +37,35 @@ function printReport() {
     if (import.meta.client) window.print();
 }
 
-useHead(() => ({
-    title: report.value ? `${report.value.name} — Report` : 'Shared Report',
-}));
+useHead(() => {
+    const title = report.value ? `${report.value.name} — Report` : 'Shared Report';
+    const description = report.value?.description || 'Shared report from Data Research Analysis';
+    const currentUrl = typeof window !== 'undefined' ? window.location.href : '';
+    const brandedLogo = branding.value?.enabled && branding.value?.logoUrl
+        ? branding.value.logoUrl
+        : 'https://dataresearchanalysis.com/images/dashboard-preview.png';
+
+    return {
+        title,
+        description,
+        meta: [
+            { name: 'robots', content: 'noindex, follow' },
+            { property: 'og:type', content: 'website' },
+            { property: 'og:url', content: currentUrl },
+            { property: 'og:title', content: title },
+            { property: 'og:description', content: description },
+            { property: 'og:image', content: brandedLogo },
+            { name: 'twitter:card', content: 'summary_large_image' },
+            { name: 'twitter:url', content: currentUrl },
+            { name: 'twitter:title', content: title },
+            { name: 'twitter:description', content: description },
+            { name: 'twitter:image', content: brandedLogo },
+        ],
+        link: [
+            { rel: 'canonical', href: currentUrl },
+        ],
+    };
+});
 
 onMounted(() => {
     load();
@@ -41,14 +74,56 @@ onMounted(() => {
 
 <template>
     <div class="min-h-screen bg-gray-50">
-        <!-- Header bar -->
-        <div class="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between print:hidden">
+        <!-- Print-only branded header -->
+        <div
+            class="hidden print:flex items-center justify-between px-6 py-4 border-b"
+            :style="branding?.enabled && branding?.primaryColor
+                ? { backgroundColor: branding.primaryColor, borderColor: 'transparent' }
+                : { backgroundColor: '#1e293b', borderColor: 'transparent' }"
+        >
             <div class="flex items-center gap-3">
-                <font-awesome-icon :icon="['fas', 'chart-bar']" class="text-primary-blue-300 text-xl" />
-                <span class="text-sm font-medium text-gray-600">Shared Report</span>
+                <img
+                    v-if="branding?.enabled && branding?.logoUrl"
+                    :src="branding.logoUrl"
+                    class="h-6 w-auto object-contain"
+                    :alt="branding?.orgName ?? 'Logo'"
+                />
+            </div>
+            <span class="text-xs text-gray-400">Printed {{ new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) }}</span>
+        </div>
+
+        <!-- Interactive header bar (hidden in print) -->
+        <div
+            class="border-b px-6 py-4 flex items-center justify-between print:hidden"
+            :style="branding?.enabled && branding?.primaryColor
+                ? { backgroundColor: branding.primaryColor, borderColor: 'transparent' }
+                : { backgroundColor: '#ffffff', borderColor: '#e5e7eb' }"
+        >
+            <div class="flex items-center gap-3">
+                <img
+                    v-if="branding?.enabled && branding?.logoUrl"
+                    :src="branding.logoUrl"
+                    class="h-6 w-auto object-contain"
+                    :alt="branding?.orgName ?? 'Logo'"
+                />
+                <font-awesome-icon
+                    v-else
+                    :icon="['fas', 'chart-bar']"
+                    class="text-xl"
+                    :class="branding?.enabled ? 'text-white/70' : 'text-primary-blue-300'"
+                />
+                <span
+                    class="text-sm font-medium"
+                    :class="branding?.enabled ? 'text-white/80' : 'text-gray-600'"
+                >
+                    Shared Report
+                </span>
             </div>
             <button
-                class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
+                class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors cursor-pointer"
+                :class="branding?.enabled
+                    ? 'text-white bg-white/10 border border-white/30 hover:bg-white/20'
+                    : 'text-gray-600 bg-white border border-gray-300 hover:bg-gray-50'"
                 @click="printReport"
             >
                 <font-awesome-icon :icon="['fas', 'print']" />
@@ -71,11 +146,11 @@ onMounted(() => {
         </div>
 
         <!-- Report content -->
-        <div v-else-if="report" class="max-w-5xl mx-auto py-10 px-4">
+        <div v-else-if="report" class="max-w-5xl mx-auto py-6 px-4 print:py-4 print:px-8">
             <!-- Title + meta -->
-            <div class="mb-8">
-                <h1 class="text-3xl font-bold text-gray-900 mb-2">{{ report.name }}</h1>
-                <p v-if="report.description" class="text-gray-500 text-base mb-3">{{ report.description }}</p>
+            <div class="mb-6 print:mb-3">
+                <h1 class="text-3xl font-bold text-gray-900 mb-2 print:text-2xl">{{ report.name }}</h1>
+                <p v-if="report.description" class="text-gray-500 text-base mb-3 print:mb-2 print:text-sm">{{ report.description }}</p>
                 <div class="flex items-center gap-4 text-xs text-gray-400">
                     <span v-if="report.created_by_name">
                         <font-awesome-icon :icon="['fas', 'user']" class="mr-1" />
@@ -83,34 +158,29 @@ onMounted(() => {
                     </span>
                     <span v-if="report.updated_at">
                         <font-awesome-icon :icon="['fas', 'clock']" class="mr-1" />
-                        Last updated
                         {{ new Date(report.updated_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) }}
-                    </span>
-                    <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-100 text-green-700 font-medium">
-                        <font-awesome-icon :icon="['fas', 'circle-check']" />
-                        Published
                     </span>
                 </div>
             </div>
 
             <!-- Items -->
-            <div v-if="report.items && report.items.length > 0" class="flex flex-col gap-8">
+            <div v-if="report.items && report.items.length > 0" class="flex flex-col gap-6 print:gap-3">
                 <div
                     v-for="(item, idx) in report.items"
                     :key="item.id ?? idx"
+                    class="public-report-item"
                 >
                     <!-- Dashboard item: embed via iframe if share key available -->
                     <template v-if="item.item_type === 'dashboard'">
-                        <div class="mb-3 flex items-center gap-2">
+                        <div class="mb-2 flex items-center gap-2">
                             <div class="w-7 h-7 rounded-lg bg-blue-50 flex items-center justify-center shrink-0">
                                 <font-awesome-icon :icon="['fas', 'table-columns']" class="text-blue-400 text-xs" />
                             </div>
-                            <h3 class="font-semibold text-gray-800 text-base">
+                            <h3 class="font-semibold text-gray-800 text-base print:text-sm">
                                 {{ item.resolved_title || item.title_override || `Dashboard #${item.ref_id ?? idx + 1}` }}
                             </h3>
                             <span class="text-xs text-gray-400">#{{ idx + 1 }}</span>
                         </div>
-                        <!-- Embedded dashboard -->
                         <div v-if="item.dashboard_share_key" class="w-full rounded-xl overflow-hidden border border-gray-200 shadow-sm bg-white">
                             <iframe
                                 :src="`/public-dashboard/${item.dashboard_share_key}`"
@@ -120,7 +190,6 @@ onMounted(() => {
                                 :title="item.resolved_title || `Dashboard #${item.ref_id}`"
                             />
                         </div>
-                        <!-- Dashboard has no public share link -->
                         <div v-else class="flex flex-col items-center justify-center py-10 bg-white rounded-xl border border-dashed border-gray-300 text-center">
                             <font-awesome-icon :icon="['fas', 'lock']" class="text-3xl text-gray-300 mb-3" />
                             <p class="text-sm font-medium text-gray-500 mb-1">Dashboard not publicly shared</p>
@@ -128,13 +197,12 @@ onMounted(() => {
                         </div>
                     </template>
 
-                    <!-- Text block item -->
                     <template v-else-if="item.item_type === 'text_block'">
-                        <div class="mb-3 flex items-center gap-2">
+                        <div class="mb-2 flex items-center gap-2">
                             <div class="w-7 h-7 rounded-lg bg-gray-50 flex items-center justify-center shrink-0">
                                 <font-awesome-icon :icon="['fas', 'align-left']" class="text-gray-400 text-xs" />
                             </div>
-                            <h3 class="font-semibold text-gray-800 text-base">
+                            <h3 class="font-semibold text-gray-800 text-base print:text-sm">
                                 {{ item.resolved_title || item.title_override || 'Text Block' }}
                             </h3>
                             <span class="text-xs text-gray-400">#{{ idx + 1 }}</span>
@@ -149,13 +217,12 @@ onMounted(() => {
                         </div>
                     </template>
 
-                    <!-- AI Insights item -->
                     <template v-else-if="item.item_type === 'ai_insight'">
-                        <div class="mb-3 flex items-center gap-2">
+                        <div class="mb-2 flex items-center gap-2">
                             <div class="w-7 h-7 rounded-lg bg-violet-50 flex items-center justify-center shrink-0">
                                 <font-awesome-icon :icon="['fas', 'wand-magic-sparkles']" class="text-violet-400 text-xs" />
                             </div>
-                            <h3 class="font-semibold text-gray-800 text-base">
+                            <h3 class="font-semibold text-gray-800 text-base print:text-sm">
                                 {{ item.resolved_title || item.title_override || 'AI Insights' }}
                             </h3>
                             <span class="text-xs text-gray-400">#{{ idx + 1 }}</span>
@@ -173,13 +240,12 @@ onMounted(() => {
                         </div>
                     </template>
 
-                    <!-- KPI Cards item -->
                     <template v-else-if="item.item_type === 'kpi_card'">
-                        <div class="mb-3 flex items-center gap-2">
+                        <div class="mb-2 flex items-center gap-2">
                             <div class="w-7 h-7 rounded-lg bg-emerald-50 flex items-center justify-center shrink-0">
                                 <font-awesome-icon :icon="['fas', 'gauge-high']" class="text-emerald-400 text-xs" />
                             </div>
-                            <h3 class="font-semibold text-gray-800 text-base">
+                            <h3 class="font-semibold text-gray-800 text-base print:text-sm">
                                 {{ item.resolved_title || item.title_override || 'KPI Cards' }}
                             </h3>
                             <span class="text-xs text-gray-400">#{{ idx + 1 }}</span>
@@ -195,13 +261,12 @@ onMounted(() => {
                         </div>
                     </template>
 
-                    <!-- Data Table item -->
                     <template v-else-if="item.item_type === 'data_table'">
-                        <div class="mb-3 flex items-center gap-2">
+                        <div class="mb-2 flex items-center gap-2">
                             <div class="w-7 h-7 rounded-lg bg-cyan-50 flex items-center justify-center shrink-0">
                                 <font-awesome-icon :icon="['fas', 'table']" class="text-cyan-400 text-xs" />
                             </div>
-                            <h3 class="font-semibold text-gray-800 text-base">
+                            <h3 class="font-semibold text-gray-800 text-base print:text-sm">
                                 {{ item.resolved_title || item.title_override || 'Data Table' }}
                             </h3>
                             <span class="text-xs text-gray-400">#{{ idx + 1 }}</span>
@@ -213,7 +278,6 @@ onMounted(() => {
                         />
                     </template>
 
-                    <!-- Other item types (widget, insight) -->
                     <template v-else>
                         <div class="flex items-center gap-4 p-4 bg-white rounded-xl border border-gray-200 shadow-sm">
                             <div class="shrink-0 w-10 h-10 rounded-lg flex items-center justify-center"
@@ -238,14 +302,23 @@ onMounted(() => {
                 </div>
             </div>
 
-            <!-- No items -->
             <div v-else class="bg-white rounded-xl border border-gray-200 p-10 text-center">
                 <font-awesome-icon :icon="['fas', 'layer-group']" class="text-4xl text-gray-200 mb-3" />
                 <p class="text-sm text-gray-400">This report has no content items.</p>
             </div>
 
-            <!-- Footer -->
-            <div class="mt-10 pt-6 border-t border-gray-200 text-center print:hidden">
+            <!-- Print-visible footer -->
+            <div class="hidden print:block mt-6 pt-3 border-t border-gray-200 text-center">
+                <p class="text-xs text-gray-400">
+                    Shared via Data Research Analysis
+                    <span v-if="report.share_expires_at">
+                        &mdash; Expires {{ new Date(report.share_expires_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) }}
+                    </span>
+                </p>
+            </div>
+
+            <!-- Interactive footer (hidden in print) -->
+            <div class="mt-8 pt-6 border-t border-gray-200 text-center print:hidden">
                 <p class="text-xs text-gray-400">
                     This report was shared using Data Research Analysis.
                     <span v-if="report.share_expires_at">


### PR DESCRIPTION
## Description

This PR ships the organization branding feature and critical fixes to the email system's unsubscribe/preference enforcement.

### Organization Branding (DRA-349)

Organizations on Professional Plus and higher tiers can now customize their visual identity across the platform:

- **Branding Settings Page** — A new `/organizations/settings/branding` page with color pickers, logo upload, enable/disable toggle, and live preview. Accessible via a "Branding" link in the organization navbar dropdown for admin/owner roles.
- **Color System** — Primary and secondary brand colors are stored on `dra_organizations`, applied via CSS custom properties on `:root`, and automatically derive a full HSL palette (lighter, darker, contrast variants) via the `useBranding` composable. Tailwind `@theme` references these properties for consistent styling.
- **Logo Upload** — Organizations can upload a brand logo via the existing admin image upload endpoint (`POST /admin/image/upload`), with the URL stored in `branding_logo_url`.
- **BrandingService** — Singleton with Redis caching, hex color validation, and tier eligibility checks (tier_rank >= 30). Exposes public branding via `GET /organizations/:id/branding`.
- **Public Dashboard & Report Branding** — Branding is injected into public dashboard and report endpoints. Public dashboards now render the branded logo at proper sizing (`h-6 w-auto`), include a dynamic branded header in exported images, and add a "Powered by {Organization}" watermark. Public reports include branded OG/Twitter meta tags, branded print headers, compact print spacing, and a print-visible footer.
- **Paddle Integration** — Subscription tier form includes fields for `paddle_product_id`, `paddle_price_id_monthly`, and `paddle_price_id_annual`. Docker env file is included in the backend image.

### Email Unsubscribe/Preference Enforcement (Bug Fixes)

The email funnel and subscription notification systems had significant gaps where unsubscribed users could still receive emails:

- **Funnel Steps** — `processReadySteps()` in `EmailFunnelProcessor` now calls `isUnsubscribed()` before sending each funnel step, checking both funnel-specific and global (`funnel_id=null`) unsubscribe records. Deactivates the enrollment when the user has opted out. Also checks `DRAUsersPlatform.unsubscribe_from_emails_at` for registered users.
- **Blog Digests** — `sendBlogDigest()` now skips recipients who have unsubscribed, tracking a `skipped` counter alongside `sent` in the return value.
- **Broadcasts** — `processBroadcasts()` now calls `isUnsubscribed()` for each subscriber across all broadcast audience types (`blog_subscribers`, `lead_generator_downloads`, `enterprise_queries`, `enterprise_contact_requests`), not just `registered_users`.
- **Subscription Emails** — `SubscriptionProcessor` now checks the `subscription_updates` email preference before sending subscription activated, upgraded, downgraded, and cancelled notifications. Resolves the organization owner's user ID to retrieve their `dra_email_preferences` settings. Payment failure, grace period expiry, and expiration downgrade emails remain unrestricted as critical transactional notifications.

### Other Fixes
- Normalized subscription tier name checks to `'Free'` (case-sensitive) across `AuthProcessor` and `SubscriptionProcessor`
- Removed Print/PDF button from report edit page

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🛠 Refactor (non-breaking change, code improvements)
- [ ] 📚 Documentation update
- [ ] 🔥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (adding or updating tests)

## How Has This Been Tested?

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

TypeScript compilation passes cleanly (`tsc --noEmit`). The email unsubscribe checks use existing `isUnsubscribed()` and `canSendEmail()` methods that were already in the codebase but never called from the sending paths. The branding feature has been staged and tested against Professional Plus tier organizations.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My code follows the code style of this project.
- [ ] I have added necessary tests.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings or errors.
- [x] I have linked the related issue(s) in the description.

## Screenshots
<img width="780" height="507" alt="image" src="https://github.com/user-attachments/assets/37223544-837c-4177-80de-6b649b8fbd2f" />
<img width="1920" height="2458" alt="image" src="https://github.com/user-attachments/assets/9e98123b-40a7-427f-8471-8edfd1638bd4" />


